### PR TITLE
feat(cli): enhance project detection and file generation with TypeScript path mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ public/dist
 .vscode
 
 **/coverage
+
+# Test projects for CLI testing
+test-projects/

--- a/docs/content/docs/api/cli/cli-setup.mdx
+++ b/docs/content/docs/api/cli/cli-setup.mdx
@@ -13,6 +13,10 @@ import { Files, Folder, File } from 'fumadocs-ui/components/files'
 **🚀 Recommended**: Use our CLI for the fastest setup experience
 </Callout>
 
+<Callout type="warning">
+**Next.js Only**: The pushduck CLI currently only supports Next.js projects. Support for other frameworks is coming soon.
+</Callout>
+
 ## Quick Start
 
 Get your file uploads working in under 2 minutes with our interactive CLI tool.

--- a/docs/content/docs/getting-started/quick-start.mdx
+++ b/docs/content/docs/getting-started/quick-start.mdx
@@ -348,6 +348,10 @@ Here's exactly what happens when you run the CLI and how to make the best choice
 
 ---
 
+<Callout type="warning">
+**Next.js Only**: The pushduck CLI currently only supports Next.js projects. Support for other frameworks is coming soon.
+</Callout>
+
 ## Common CLI Scenarios
 
 ### First-Time Setup (Recommended)


### PR DESCRIPTION
- Added support for parsing TypeScript path mappings from tsconfig.json.
- Updated project detection logic to include src directory structure.
- Enhanced file generation functions to resolve import paths based on path mappings.
- Improved directory creation logic to accommodate src directory usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for projects using a `src` directory structure, automatically detecting and adapting generated files and imports.
  * Enhanced detection and utilization of TypeScript path aliases and base URLs from `tsconfig.json` for more accurate import paths in generated files.

* **Bug Fixes**
  * Import statements in generated files now correctly reflect project directory structure and TypeScript path aliases, reducing incorrect or broken imports.

* **Documentation**
  * Added warnings in CLI setup and quick start guides clarifying that the CLI currently supports only Next.js projects, with other frameworks planned for future support.

* **Chores**
  * Updated ignore rules to exclude test projects used for CLI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->