### PR TITLE
feat: unify event hook naming (onStart/onProgress/onComplete/onError)

### DIFF
--- a/packages/pushduck/src/__tests__/expires-in.test.ts
+++ b/packages/pushduck/src/__tests__/expires-in.test.ts
@@ -170,26 +170,26 @@ describe(".middleware() config preservation (regression)", () => {
     expect(route._getConfig().paths?.prefix).toBe("uploads");
   });
 
-  it("preserves onUploadComplete when .middleware() is called after", () => {
+  it("preserves onComplete when .middleware() is called after", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
     const route = s3
       .file()
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ userId: "123" }));
 
-    expect(route._getConfig().onUploadComplete).toBe(hook);
+    expect(route._getConfig().onComplete).toBe(hook);
   });
 
   it("preserves all config when multiple .middleware() calls are chained", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
-    // expiresIn and onUploadComplete start an S3Route; paths and further
+    // expiresIn and onComplete start an S3Route; paths and further
     // middleware calls must also preserve the accumulated config
     const route = s3
       .file()
       .expiresIn(600)
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ step: 1 }))
       .paths({ prefix: "docs" })
       .middleware(async ({ metadata }) => ({ ...metadata, step: 2 }));
@@ -197,7 +197,7 @@ describe(".middleware() config preservation (regression)", () => {
     const config = route._getConfig();
     expect(config.expiresIn).toBe(600);
     expect(config.paths?.prefix).toBe("docs");
-    expect(config.onUploadComplete).toBe(hook);
+    expect(config.onComplete).toBe(hook);
     expect(config.middleware).toHaveLength(2);
   });
 

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -463,8 +463,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   onUploadStart(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadStart = hook;
-    return this;
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return this.onStart(hook);
   }
 
   /**
@@ -473,34 +473,85 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    *
    * @param hook - Function to execute on upload progress
    * @returns This route instance for chaining
-   *
-   * @example Progress Tracking
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await updateUploadProgress(metadata.uploadId, {
-   *     fileName: file.name,
-   *     progress,
-   *     status: progress === 100 ? 'completing' : 'uploading',
-   *   });
-   * });
-   * ```
-   *
-   * @example Real-time Updates
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await sendProgressUpdate(metadata.userId, {
-   *     fileName: file.name,
-   *     percentComplete: progress,
-   *   });
-   * });
-   * ```
+   * @deprecated Use `.onProgress()` instead.
    */
   onUploadProgress(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { progress: number }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadProgress = hook;
+    console.warn('⚠️ pushduck: .onUploadProgress() is deprecated. Use .onProgress() instead.');
+    return this.onProgress(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   * Ideal for database updates, post-processing, and success notifications.
+   *
+   * @param hook - Function to execute on upload completion
+   * @returns This route instance for chaining
+   * @deprecated Use `.onComplete()` instead.
+   */
+  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return this.onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   * Essential for error logging, cleanup, and user notifications.
+   *
+   * @param hook - Function to execute on upload error
+   * @returns This route instance for chaining
+   * @deprecated Use `.onError()` instead.
+   */
+  onUploadError(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { error: Error }
+    ) => Promise<void> | void
+  ): this {
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return this.onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   * Useful for logging, initializing progress tracking, or sending notifications.
+   *
+   * @param hook - Function to execute on upload start
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onStart = hook;
+    return this;
+  }
+
+  /**
+   * Adds a hook that executes during file upload progress.
+   *
+   * @param hook - Function to execute on upload progress
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onProgress(async ({ file, metadata, progress }) => {
+   *   await updateUploadProgress(metadata.uploadId, { progress });
+   * });
+   * ```
+   */
+  onProgress(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { progress: number }
+    ) => Promise<void> | void
+  ): this {
+    this.config.onProgress = hook;
     return this;
   }
 
@@ -511,100 +562,37 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * @param hook - Function to execute on upload completion
    * @returns This route instance for chaining
    *
-   * @example Database Update
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, key, metadata }) => {
-   *   await db.files.create({
-   *     name: file.name,
-   *     size: file.size,
-   *     type: file.type,
-   *     url: url,
-   *     key: key,
-   *     uploadedBy: metadata.userId,
-   *     uploadedAt: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Post-processing
-   * ```typescript
-   * const route = s3.image().onUploadComplete(async ({ file, key, metadata }) => {
-   *   // Generate thumbnails for images
-   *   await generateThumbnails(key, {
-   *     sizes: [100, 300, 600],
-   *     userId: metadata.userId,
-   *   });
-   * });
-   * ```
-   *
-   * @example Notification System
-   * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_success',
-   *     message: `File "${file.name}" uploaded successfully`,
-   *     fileUrl: url,
-   *   });
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
    * });
    * ```
    */
-  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadComplete = hook;
+  onComplete(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onComplete = hook;
     return this;
   }
 
   /**
    * Adds a hook that executes when file upload fails.
-   * Essential for error logging, cleanup, and user notifications.
    *
    * @param hook - Function to execute on upload error
    * @returns This route instance for chaining
    *
-   * @example Error Logging
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   console.error(`Upload failed: ${file.name}`, error);
-   *   await logUploadError({
-   *     fileName: file.name,
-   *     error: error.message,
-   *     stack: error.stack,
-   *     userId: metadata.userId,
-   *     timestamp: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Cleanup and Retry
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   // Clean up any partial uploads
-   *   await cleanupPartialUpload(file.name, metadata.uploadId);
-   *
-   *   // Queue for retry if appropriate
-   *   if (isRetryableError(error)) {
-   *     await queueUploadRetry(file.name, metadata);
-   *   }
-   * });
-   * ```
-   *
-   * @example User Notification
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_error',
-   *     message: `Failed to upload "${file.name}": ${error.message}`,
-   *   });
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
    * });
    * ```
    */
-  onUploadError(
+  onError(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { error: Error }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadError = hook;
+    this.config.onError = hook;
     return this;
   }
 
@@ -636,14 +624,26 @@ interface S3RouteConfig<TMetadata = any> {
   /** Presigned upload URL expiration time in seconds (default: 3600 = 1 hour) */
   expiresIn?: number;
   /** Hook for upload start events */
-  onUploadStart?: S3LifecycleHook<TMetadata>;
+  onStart?: S3LifecycleHook<TMetadata>;
   /** Hook for upload progress events */
-  onUploadProgress?: (
+  onProgress?: (
     ctx: S3LifecycleContext<TMetadata> & { progress: number }
   ) => Promise<void> | void;
   /** Hook for upload completion events */
-  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  onComplete?: S3LifecycleHook<TMetadata>;
   /** Hook for upload error events */
+  onError?: (
+    ctx: S3LifecycleContext<TMetadata> & { error: Error }
+  ) => Promise<void> | void;
+  /** @deprecated Use onStart */
+  onUploadStart?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onProgress */
+  onUploadProgress?: (
+    ctx: S3LifecycleContext<TMetadata> & { progress: number }
+  ) => Promise<void> | void;
+  /** @deprecated Use onComplete */
+  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onError */
   onUploadError?: (
     ctx: S3LifecycleContext<TMetadata> & { error: Error }
   ) => Promise<void> | void;
@@ -885,9 +885,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           );
         }
 
-        // 3. Call onUploadStart hook
-        if (routeConfig.onUploadStart) {
-          await routeConfig.onUploadStart({ file, metadata: fileMetadata });
+        // 3. Call onStart hook (supports both new and deprecated name)
+        const onStartHook = routeConfig.onStart || routeConfig.onUploadStart;
+        if (onStartHook) {
+          await onStartHook({ file, metadata: fileMetadata });
         }
 
         // 4. Generate hierarchical file key
@@ -947,9 +948,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
             ? error
             : new Error("Failed to generate presigned URL");
 
-        // Call onUploadError hook with enriched metadata
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file,
             metadata: fileMetadata,
             error: err,
@@ -993,9 +995,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           3600
         );
 
-        // Call onUploadComplete hook
-        if (routeConfig.onUploadComplete) {
-          await routeConfig.onUploadComplete({
+        // Call onComplete hook (supports both new and deprecated name)
+        const onCompleteHook = routeConfig.onComplete || routeConfig.onUploadComplete;
+        if (onCompleteHook) {
+          await onCompleteHook({
             file: completion.file,
             metadata: completion.metadata || {},
             url,
@@ -1016,9 +1019,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
             ? error
             : new Error("Upload completion failed");
 
-        // Call onUploadError hook
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file: completion.file,
             metadata: completion.metadata || {},
             error: err,

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -872,13 +872,36 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onStart()` instead.
+   */
   onUploadStart(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
       metadata: any;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadStart(hook);
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return new S3Route(this).onStart(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onStart(hook);
   }
 
   /**
@@ -916,6 +939,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onComplete()` instead.
+   */
   onUploadComplete(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -924,7 +950,29 @@ export class S3FileSchema extends S3Schema<File, File> {
       key?: string;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadComplete(hook);
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return new S3Route(this).onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
+   * });
+   * ```
+   */
+  onComplete(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      url?: string;
+      key?: string;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onComplete(hook);
   }
 
   /**
@@ -959,6 +1007,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onError()` instead.
+   */
   onUploadError(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -966,7 +1017,28 @@ export class S3FileSchema extends S3Schema<File, File> {
       error: Error;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadError(hook);
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return new S3Route(this).onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
+   * });
+   * ```
+   */
+  onError(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      error: Error;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onError(hook);
   }
 
   /**

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -665,13 +665,17 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
           }
         }
 
-        if (config.onSuccess) {
+        const successCallback = config.onComplete || config.onSuccess;
+        if (successCallback) {
+          if (config.onSuccess && !config.onComplete) {
+            console.warn('⚠️ pushduck: onSuccess is deprecated. Use onComplete instead.');
+          }
           setFiles((currentFiles) => {
             const finalFiles = currentFiles.filter(
               (f) => f.status === "success"
             );
             if (finalFiles.length > 0) {
-              config.onSuccess?.(finalFiles);
+              successCallback(finalFiles);
             }
             return currentFiles;
           });

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -38,6 +38,9 @@ export interface UploadRouteConfig {
   endpoint?: string;
   fetcher?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
   onStart?: (files: S3FileMetadata[]) => void | Promise<void>;
+  /** Called when all uploads complete successfully. Preferred over onSuccess. */
+  onComplete?: (results: S3UploadedFile[]) => void | Promise<void>;
+  /** @deprecated Use onComplete instead. */
   onSuccess?: (results: S3UploadedFile[]) => void | Promise<void>;
   onError?: (error: Error) => void;
   onProgress?: (progress: number) => void;


### PR DESCRIPTION
## Problem

Server and client used different names for the same lifecycle events:

| Event | Server (before) | Client (before) |
|---|---|---|
| Upload starts | `onUploadStart` | `onStart` |
| Progress update | `onUploadProgress` | `onProgress` |
| Upload completes | `onUploadComplete` | `onSuccess` |
| Upload fails | `onUploadError` | `onError` |

This forced developers to memorize two vocabularies and made copy-pasting between server/client configs error-prone.

## Changes

New unified API — same names everywhere:
- `.onStart()` — replaces `.onUploadStart()`
- `.onProgress()` — replaces `.onUploadProgress()`  
- `.onComplete()` — replaces `.onUploadComplete()` AND client `onSuccess`
- `.onError()` — replaces `.onUploadError()`

Old names kept with `console.warn()` deprecation notices. All existing code continues to work.

## Files changed
- `src/core/router/router-v2.ts` — S3Route class + S3RouteConfig + invocation sites
- `src/core/schema.ts` — S3FileSchema lifecycle method delegates
- `src/types/index.ts` — UploadRouteConfig interface (added `onComplete`)
- `src/hooks/use-upload-route.ts` — reads `onComplete` with fallback to `onSuccess`
- `src/__tests__/expires-in.test.ts` — updated to use new field names

## Test plan
- [x] All 156 existing tests pass
- [x] Type check clean
- [x] Old methods (`onUploadComplete` etc.) still work, just log a deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)