### PR TITLE
feat: clarify result field names (storagePath, publicUrl, presignedUrl)

### DIFF
--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -141,10 +141,25 @@ export interface S3LifecycleContext<T = any> {
   file: S3FileMetadata;
   /** Processed metadata from middleware */
   metadata: T;
-  /** Public URL of the uploaded file (available after upload) */
-  url?: string;
-  /** Storage key/path of the uploaded file */
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public URL of the uploaded file. Never expires if bucket has public access.
+   * Store this in your database.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key?: string;
+  /** @deprecated Use `publicUrl` or `presignedUrl` instead. */
+  url?: string;
 }
 
 /**
@@ -998,6 +1013,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           await routeConfig.onUploadComplete({
             file: completion.file,
             metadata: completion.metadata || {},
+            storagePath: completion.key,
+            publicUrl: url,
+            presignedUrl,
+            // deprecated aliases
             url,
             key: completion.key,
           });
@@ -1006,7 +1025,9 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
         results.push({
           success: true,
           key: completion.key,
+          storagePath: completion.key,
           url,
+          publicUrl: url,
           presignedUrl,
           file: completion.file,
         });
@@ -1058,9 +1079,16 @@ export interface UploadCompletion {
 
 export interface CompletionResponse {
   success: boolean;
+  /** Permanent storage path — store this in your database. */
+  storagePath?: string;
+  /** Public URL — store this in your database. */
+  publicUrl?: string;
+  /** Temporary presigned download URL — expires in ~1 hour, do not store. */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key: string;
+  /** @deprecated Use `publicUrl` or `presignedUrl` instead. */
   url?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
   file?: S3FileMetadata;
   error?: string;
 }

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -588,7 +588,8 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
               updateFileStatus(fileState.id, "success", {
                 progress: 100,
-                key: result.key,
+                storagePath: result.key,
+                key: result.key, // deprecated alias
               });
 
               return {
@@ -646,9 +647,12 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
                       );
                       if (fileToUpdate) {
                         updateFileStatus(fileToUpdate.id, "success", {
-                          url: result.url,
-                          key: result.key,
+                          storagePath: result.key,
+                          publicUrl: result.url,
                           presignedUrl: result.presignedUrl,
+                          // deprecated aliases
+                          key: result.key,
+                          url: result.url,
                           progress: 100,
                         });
                       }

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -16,9 +16,31 @@ export interface S3UploadedFile {
   type: string;
   status: "pending" | "uploading" | "success" | "error";
   progress: number;
-  url?: string;
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public CDN URL if the bucket/provider has public access configured.
+   * Store this in your database — it never expires.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /**
+   * @deprecated Use `storagePath` instead. Will be removed in 1.0.0.
+   * The S3 object key — same value as storagePath.
+   */
   key?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
+  /**
+   * @deprecated Use `publicUrl` or `presignedUrl` instead. Will be removed in 1.0.0.
+   * Previously returned the public URL; now ambiguous with presignedUrl.
+   */
+  url?: string;
   error?: string;
   file?: File;
   // ETA tracking


### PR DESCRIPTION
## Problem

`S3UploadedFile` had `url` and `key` with no indication of which to store in a database:
- `url` — could be a presigned URL (expires in ~1h) or a public URL depending on config
- `key` — the permanent S3 key, but nothing told users this was the safe one to store

This caused a common bug: users store `url` in their DB, links break after an hour.

## Changes

Three explicit fields with clear JSDoc:

| Field | Meaning | Store in DB? |
|---|---|---|
| `storagePath` | S3 key/path (e.g. `uploads/user/photo.jpg`) | ✅ Yes — never expires |
| `publicUrl` | Public URL when bucket has public access | ✅ Yes — never expires |
| `presignedUrl` | Temporary download URL | ❌ No — expires in ~1h |

Old `key` and `url` fields kept with `@deprecated` JSDoc — same values, no behavior change.

Applied to: `S3UploadedFile`, `S3LifecycleContext`, `CompletionResponse`.

## Test plan
- [x] All 156 tests pass
- [x] Type check clean
- [x] Old `key`/`url` fields still present and populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)