### PR TITLE
feat: uploadFiles() now returns Promise<S3UploadedFile[]>

### DIFF
--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -468,10 +468,10 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
    * ```
    */
   const startUpload = useCallback(
-    async (uploadFiles: File[], metadata?: any) => {
+    async (uploadFiles: File[], metadata?: any): Promise<S3UploadedFile[]> => {
       if (!uploadFiles.length) {
         setIsUploading(false);
-        return;
+        return [];
       }
 
       try {
@@ -525,7 +525,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
           // Call onError callback for server errors
           config.onError?.(new Error(errorMessage));
-          return;
+          return [];
         }
 
         const presignData = await presignResponse.json();
@@ -545,7 +545,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
           // Call onError callback for presigned URL failures
           config.onError?.(new Error(errorMessage));
-          return;
+          return [];
         }
 
         // Upload validation passed - call onStart callback and initialize progress
@@ -618,6 +618,9 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
         const uploadResults = await Promise.all(uploadPromises);
         const successfulUploads = uploadResults.filter(Boolean);
 
+        // Track final completed files for the return value
+        const completedFiles: S3UploadedFile[] = [];
+
         if (successfulUploads.length > 0) {
           try {
             const completeResponse = await fetcher(
@@ -651,6 +654,15 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
                           presignedUrl: result.presignedUrl,
                           progress: 100,
                         });
+                        // Collect for return value
+                        completedFiles.push({
+                          ...fileToUpdate,
+                          status: "success",
+                          progress: 100,
+                          url: result.url,
+                          key: result.key,
+                          presignedUrl: result.presignedUrl,
+                        });
                       }
                     }
                   }
@@ -676,6 +688,8 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
             return currentFiles;
           });
         }
+
+        return completedFiles;
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : "Upload failed";
@@ -693,6 +707,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
         config.onError?.(
           error instanceof Error ? error : new Error(errorMessage)
         );
+        return [];
       } finally {
         setIsUploading(false);
         abortControllers.current.clear();

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -89,7 +89,17 @@ export interface S3RouteUploadResult {
    * await uploadFiles(files, { albumId: '123', tags: ['vacation'] });
    * ```
    */
-  uploadFiles: (files: File[], metadata?: any) => Promise<void>;
+  /**
+   * Upload files and await the results directly.
+   * Returns the completed file objects — no need to watch `files` state or use `onSuccess`.
+   *
+   * @example
+   * ```typescript
+   * const results = await uploadFiles(selectedFiles);
+   * await db.save({ path: results[0].key });
+   * ```
+   */
+  uploadFiles: (files: File[], metadata?: any) => Promise<S3UploadedFile[]>;
 
   /** Reset upload state and clear files */
   reset: () => void;


### PR DESCRIPTION
## Problem

`uploadFiles()` returned `void` — to get upload results you had to either:
- Pass an `onSuccess` callback (callback hell)
- Watch the `files` state array (works for UI but awkward for logic)

```ts
// Before — forced callback pattern
const { uploadFiles } = useUploadRoute('avatars', {
  onSuccess: (results) => {
    db.save({ path: results[0].key }); // can't await this naturally
  }
});
await uploadFiles(files); // returns nothing
```

## Change

`uploadFiles()` now returns `Promise<S3UploadedFile[]>`:

```ts
// After — direct await
const { uploadFiles } = useUploadRoute('avatars');
const results = await uploadFiles(files);
await db.save({ path: results[0].key });
```

## Backward compatibility
- Existing `await uploadFiles(files)` with void usage still works (just ignores the return)
- `onSuccess` callback still fires as before
- Returns `[]` on error (error is still reported via `errors` state and `onError` callback)

## Test plan
- [x] All 156 tests pass
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)