### PR TITLE
feat: unify schema method naming (accept, maxSize, minSize)

### DIFF
--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -87,6 +87,13 @@ export interface S3FileConstraints {
   maxSize?: string | number;
   /** Minimum file size (string like '1KB' or number in bytes) */
   minSize?: string | number;
+  /**
+   * Accepted file types — mirrors HTML `<input accept>`.
+   * Supports MIME types (`'image/jpeg'`), wildcards (`'image/*'`),
+   * and extensions with dots (`'.pdf'`). Mixes are allowed.
+   * @example s3.file({ accept: ['image/*', '.pdf'] })
+   */
+  accept?: string | string[];
   /** Allowed MIME types (e.g., ['image/jpeg', 'application/pdf']) */
   allowedTypes?: string[];
   /** Allowed file extensions (e.g., ['.jpg', '.pdf']) */
@@ -589,6 +596,23 @@ export class S3FileSchema extends S3Schema<File, File> {
    */
   constructor(protected constraints: S3FileConstraints = {}) {
     super();
+    // Process `accept` shorthand into allowedTypes / allowedExtensions
+    if (constraints.accept) {
+      const acceptArray = Array.isArray(constraints.accept)
+        ? constraints.accept
+        : [constraints.accept];
+      const mimeTypes = acceptArray.filter((t) => !t.startsWith("."));
+      const exts = acceptArray
+        .filter((t) => t.startsWith("."))
+        .map((e) => e.slice(1)); // strip leading dot for internal storage
+      if (mimeTypes.length && !constraints.allowedTypes) {
+        constraints = { ...constraints, allowedTypes: mimeTypes };
+      }
+      if (exts.length && !constraints.allowedExtensions) {
+        constraints = { ...constraints, allowedExtensions: exts };
+      }
+      this.constraints = constraints;
+    }
     this._constraints = { ...constraints };
   }
 
@@ -688,11 +712,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
    * ```
    */
+  /** @deprecated Use `.maxSize()` instead. */
   max(size: string | number): S3FileSchema {
     console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
+      "⚠️ pushduck: .max() is deprecated. Use .maxSize() instead."
     );
-    return new S3FileSchema({ ...this.constraints, maxSize: size });
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  maxFileSize(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead."
+    );
+    return this.maxSize(size);
   }
 
   /**
@@ -703,12 +736,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().maxFileSize('10MB');
-   * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
+   * upload.file().maxSize('10MB')
+   * upload.file().maxSize(10485760) // 10MB in bytes
    * ```
    */
-  maxFileSize(size: string | number): S3FileSchema {
+  maxSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, maxSize: size });
+  }
+
+  /** @deprecated Use `.minSize()` instead. */
+  min(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .min() is deprecated. Use .minSize() instead."
+    );
+    return this.minSize(size);
   }
 
   /**
@@ -719,53 +760,54 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().min('1KB');
-   * const schema2 = s3.file().min(1024); // 1KB in bytes
+   * upload.file().minSize('1KB')
    * ```
    */
-  min(size: string | number): S3FileSchema {
+  minSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, minSize: size });
   }
 
   /**
-   * Sets the allowed MIME types constraint.
+   * Sets accepted file types — mirrors HTML `<input accept>`.
+   * Replaces `.types()` and `.extensions()` with a single unified method.
    *
-   * @param allowedTypes - Array of allowed MIME types
-   * @returns New schema instance with MIME type constraint
-   *
+   * Supports MIME types, wildcards, and extensions (with dots):
    * @example
    * ```typescript
-   * const imageSchema = s3.file().types([
-   *   'image/jpeg',
-   *   'image/png',
-   *   'image/webp'
-   * ]);
-   *
-   * const documentSchema = s3.file().types([
-   *   'application/pdf',
-   *   'application/msword',
-   *   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-   * ]);
+   * upload.file().accept('image/*')
+   * upload.file().accept(['image/jpeg', 'image/png'])
+   * upload.file().accept(['.pdf', '.doc'])
+   * upload.file().accept(['image/*', '.pdf']) // mixed
    * ```
    */
-  types(allowedTypes: string[]): S3FileSchema {
-    return new S3FileSchema({ ...this.constraints, allowedTypes });
+  accept(types: string | string[]): S3FileSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray
+      .filter((t) => t.startsWith("."))
+      .map((e) => e.slice(1)); // strip leading dot
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3FileSchema(newConstraints);
   }
 
-  /**
-   * Sets the allowed file extensions constraint.
-   *
-   * @param allowedExtensions - Array of allowed file extensions (with or without dots)
-   * @returns New schema instance with extension constraint
-   *
-   * @example
-   * ```typescript
-   * const imageSchema = s3.file().extensions(['.jpg', '.jpeg', '.png']);
-   * const docSchema = s3.file().extensions(['pdf', 'doc', 'docx']); // dots optional
-   * ```
-   */
+  /** @deprecated Use `.accept()` instead. */
+  types(allowedTypes: string[]): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .types() is deprecated. Use .accept() instead."
+    );
+    return this.accept(allowedTypes);
+  }
+
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   extensions(allowedExtensions: string[]): S3FileSchema {
-    return new S3FileSchema({ ...this.constraints, allowedExtensions });
+    console.warn(
+      "⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead, e.g. .accept([\'.pdf\', \'.doc\'])."
+    );
+    return this.accept(
+      allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`))
+    );
   }
 
   /**
@@ -1063,43 +1105,53 @@ export class S3ImageSchema extends S3FileSchema {
     return new S3ImageSchema({ ...this.constraints, allowedTypes: mimeTypes });
   }
 
-  // Override methods to maintain S3ImageSchema type
-  /**
-   * @deprecated Use `maxFileSize()` instead. This method will be removed in a future version.
-   */
+  // Override methods to maintain S3ImageSchema return type
+  /** @deprecated Use `.maxSize()` instead. */
   override max(size: string | number): S3ImageSchema {
-    console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
-    );
+    console.warn("⚠️ pushduck: .max() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  override maxFileSize(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  override maxSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, maxSize: size });
   }
 
-  /**
-   * Sets the maximum file size constraint.
-   *
-   * @param size - Maximum size as string (e.g., '10MB', '500KB') or number (bytes)
-   * @returns New schema instance with max size constraint
-   *
-   * @example
-   * ```typescript
-   * const schema = s3.image().maxFileSize('10MB');
-   * const schema2 = s3.image().maxFileSize(10485760); // 10MB in bytes
-   * ```
-   */
-  maxFileSize(size: string | number): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, maxSize: size });
-  }
-
+  /** @deprecated Use `.minSize()` instead. */
   override min(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .min() is deprecated. Use .minSize() instead.");
+    return this.minSize(size);
+  }
+
+  override minSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, minSize: size });
   }
 
-  override types(allowedTypes: string[]): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, allowedTypes });
+  override accept(types: string | string[]): S3ImageSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray.filter((t) => t.startsWith(".")).map((e) => e.slice(1));
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3ImageSchema(newConstraints);
   }
 
+  /** @deprecated Use `.accept()` instead. */
+  override types(allowedTypes: string[]): S3ImageSchema {
+    console.warn("⚠️ pushduck: .types() is deprecated. Use .accept() instead.");
+    return this.accept(allowedTypes);
+  }
+
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   override extensions(allowedExtensions: string[]): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, allowedExtensions });
+    console.warn("⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead.");
+    return this.accept(allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`)));
   }
 
   /**


### PR DESCRIPTION
## Problem

Three inconsistencies in the chainable schema API:

1. `.types(['image/jpeg'])` and `.extensions(['.pdf'])` are separate methods with no unified shorthand — but the HTML `<input accept>` attribute handles both in one attribute
2. `.maxFileSize()` is verbose; `.min()` is short — asymmetric naming
3. Object form uses `allowedTypes` but chain uses `.types()` — different keys for same concept

## Changes

### `.accept(types)` — replaces `.types()` and `.extensions()`
Mirrors `<input accept>`. Works with MIME types, wildcards, and extensions:
```ts
upload.file().accept('image/*')
upload.file().accept(['image/jpeg', 'application/pdf'])
upload.file().accept(['.pdf', '.doc'])
upload.file().accept(['image/*', '.pdf'])  // mixed

// Also works in object form
upload.file({ accept: ['image/*', '.pdf'] })
```

### `.maxSize(size)` — replaces `.maxFileSize()`
```ts
upload.file().maxSize('10MB')   // was: .maxFileSize('10MB')
upload.image().maxSize('5MB')
```

### `.minSize(size)` — replaces `.min()`
```ts
upload.file().minSize('1KB')    // was: .min('1KB')
```

## Backward compatibility
All old methods kept with `console.warn()` deprecation notices:
- `.types()` → `.accept()`
- `.extensions()` → `.accept(['.ext'])`
- `.maxFileSize()` → `.maxSize()`
- `.max()` → `.maxSize()` (was already deprecated, warning message updated)
- `.min()` → `.minSize()`

## Test plan
- [x] All 156 tests pass
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)