### PR TITLE
feat: add upload.* as provider-neutral alias for s3.*

### DIFF
--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -628,13 +628,20 @@ export class UploadConfigBuilder {
     // Create storage instance with config
     const storage = createStorage(finalConfig);
 
-    // Create S3 builder instance with config
-    const s3 = createS3Instance(finalConfig);
+    // Create upload builder instance with config
+    const upload = createS3Instance(finalConfig);
 
     return {
       config: finalConfig,
       storage,
-      s3,
+      upload,
+      /** @deprecated Use `upload` instead. The `s3` name is misleading when using R2, MinIO, or other providers. */
+      get s3() {
+        console.warn(
+          '⚠️ pushduck: Destructuring `s3` from build() is deprecated. Use `upload` instead: const { upload } = createUploadConfig()...build()'
+        );
+        return upload;
+      },
     };
   }
 }
@@ -670,7 +677,12 @@ export interface UploadInitResult {
   config: UploadConfig;
   /** Storage instance for file operations (list, delete, info, etc.) */
   storage: StorageInstance;
-  /** S3 builder instance with schema builders and router factory */
+  /** Provider-neutral upload builder with schema builders and router factory */
+  upload: ReturnType<typeof createS3Instance>;
+  /**
+   * @deprecated Use `upload` instead.
+   * The `s3` name is misleading when using Cloudflare R2, MinIO, or other providers.
+   */
   s3: ReturnType<typeof createS3Instance>;
 }
 


### PR DESCRIPTION
## Problem

`createUploadConfig().build()` returned `{ s3 }`. When using Cloudflare R2, MinIO, or DigitalOcean Spaces:

```ts
const { s3 } = createUploadConfig()
  .provider('cloudflare-r2', { ... })
  .build();

s3.file()  // Why is R2 called s3?
```

This contradicts the library's "provider-agnostic" positioning and confuses developers not using AWS.

## Change

`build()` now returns `{ upload, s3 }`:

```ts
const { upload } = createUploadConfig()
  .provider('cloudflare-r2', { ... })
  .build();

upload.file().maxSize('10MB')  // Clear — works with any provider
```

`s3` is kept as a deprecated getter on the return object:
- Existing `const { s3 } = ...build()` code continues to work
- Logs a `console.warn()` pointing to `upload` as the new name

## No internal changes
The `upload` object is the exact same thing as `s3` was — purely a renaming of the destructured property.

## Test plan
- [x] All 156 tests pass
- [x] Type check clean
- [x] `const { s3 }` still works with deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)