### PR TITLE
fix: make .paths() and .expiresIn() immutable (return new instance)

### DIFF
--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -396,8 +396,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   paths(paths: S3RoutePathConfig<TMetadata>): this {
-    this.config.paths = { ...this.config.paths, ...paths };
-    return this;
+    const newConfig = { ...this.config, paths: { ...this.config.paths, ...paths } };
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**
@@ -431,8 +431,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
         `expiresIn must be between 1 and 604800 seconds (7 days), got ${seconds}`
       );
     }
-    this.config.expiresIn = seconds;
-    return this;
+    const newConfig = { ...this.config, expiresIn: seconds };
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**


### PR DESCRIPTION
## Problem

`.paths()` and `.expiresIn()` mutated `this.config` in place, while `.middleware()` correctly created a new `S3Route`. This inconsistency could silently corrupt a shared base route:

```ts
const base = s3.file().maxSize('10MB').middleware(auth);

const docsRoute   = base.paths({ prefix: 'docs' });    // mutated base!
const imagesRoute = base.paths({ prefix: 'images' });  // base was already corrupted
```

## Fix

Both methods now clone the config into a new `S3Route` instance — matching the behavior of `.middleware()`, `.refine()`, and `.transform()`:

```ts
const base = upload.file().maxSize('10MB').middleware(auth);

const docsRoute   = base.paths({ prefix: 'docs' });    // new instance ✓
const imagesRoute = base.paths({ prefix: 'images' });  // base untouched ✓
```

## Impact
This is technically a behavior change, but only visible if code was relying on mutation (which was always a bug). The immutable pattern matches every other method on the chain and the mental model of Zod-style builders.

## Test plan
- [x] All 156 tests pass (including the existing `expiresIn` config preservation tests)
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)