### PR TITLE
feat(hooks): add useUpload as explicit hook API

### DIFF
--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -209,6 +209,9 @@ export { createUploadClient } from "./client/upload-client";
  * });
  * ```
  */
+// Preferred: hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -717,3 +717,33 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
 // Export utility functions for UI components
 export { formatETA, formatUploadSpeed };
+
+/**
+ * Hook for uploading files to a typed route.
+ * Preferred over `useUploadRoute` — hooks should look like hooks.
+ *
+ * @example
+ * ```typescript
+ * const { uploadFiles, files, isUploading } = useUpload<AppRouter>('imageUpload', {
+ *   onComplete: (results) => console.log('done', results),
+ * });
+ *
+ * const results = await uploadFiles(selectedFiles);
+ * ```
+ */
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter>,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload(
+  routeName: string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter> | string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult {
+  return useUploadRoute(routeName as string, config);
+}

--- a/packages/pushduck/src/index.ts
+++ b/packages/pushduck/src/index.ts
@@ -9,7 +9,9 @@
 // HOOKS
 // ========================================
 
-// Main upload hook
+// Preferred upload hook — hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================


### PR DESCRIPTION
## Summary

- Add `useUpload<TRouter>(routeName, config?)` as the preferred hook name
- The existing `upload.routeName()` proxy pattern is invisible to linters and looks like a regular method call rather than a React hook
- Export `useUpload` from both `pushduck` and `pushduck/client`
- `useUploadRoute` kept unchanged for full backward compatibility

## Before / After

**Before** (proxy pattern — linter can't see it's a hook):
```ts
const upload = createUploadClient<AppRouter>({ endpoint: '/api/upload' });
const { uploadFiles, files } = upload.imageUpload(); // looks like a method call
```

**After** (explicit hook):
```ts
import { useUpload } from 'pushduck/client';
const { uploadFiles, files } = useUpload<AppRouter>('imageUpload'); // clearly a hook
```

## Test plan
- [x] All 156 existing tests pass
- [x] Type-check passes with no errors
- [x] Both overload signatures (generic and string) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)