### PR TITLE
feat(types): add provider-neutral type aliases

### DIFF
--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -320,4 +320,9 @@ export type {
   S3Router,
   TypedRouteHook,
   TypedUploadedFile,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";

--- a/packages/pushduck/src/index.ts
+++ b/packages/pushduck/src/index.ts
@@ -40,6 +40,11 @@ export type {
   RouterRouteNames,
   S3Router,
   TypedRouteHook,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";
 
 // ========================================

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -583,4 +583,30 @@ export type { HealthCheck, HealthCheckResult } from "./core/utils/health-check";
 
 export type { LogLevel } from "./core/utils/logger";
 
-// Legacy config types removed - use modern provider config types instead
+// ========================================
+// PROVIDER-NEUTRAL TYPE ALIASES
+// ========================================
+
+// These aliases drop the "S3" prefix so they read naturally when using R2, MinIO, or any provider.
+// The S3-prefixed originals remain fully supported.
+
+export type {
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
+} from "./types";
+
+// Schema aliases
+export type { S3FileConstraints as FileConstraints } from "./core/schema";
+export type { InferS3Input as InferFileInput, InferS3Output as InferFileOutput } from "./core/schema";
+
+// Router/lifecycle aliases
+export type {
+  S3LifecycleContext as LifecycleContext,
+  S3LifecycleHook as LifecycleHook,
+  S3Middleware as Middleware,
+  S3MiddlewareContext as MiddlewareContext,
+  S3RouteContext as RouteContext,
+  S3RouterDefinition as RouterDefinition,
+} from "./core/router/router-v2";

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -234,4 +234,31 @@ export type InferClientRouter<T> =
   }
   : never;
 
-// Legacy types removed - use TypedRouteHook and ClientConfig instead
+// ========================================
+// Provider-Neutral Type Aliases
+// ========================================
+
+/**
+ * Provider-neutral alias for S3Router.
+ * Works regardless of whether you use AWS S3, Cloudflare R2, MinIO, or any other provider.
+ * @alias S3Router
+ */
+export type UploadRouter<TRoutes extends Record<string, any> = Record<string, any>> = S3Router<TRoutes>;
+
+/**
+ * Provider-neutral alias for S3UploadedFile.
+ * @alias S3UploadedFile
+ */
+export type UploadedFile = S3UploadedFile;
+
+/**
+ * Provider-neutral alias for S3RouteUploadResult.
+ * @alias S3RouteUploadResult
+ */
+export type UploadResult = S3RouteUploadResult;
+
+/**
+ * Provider-neutral alias for RouterRouteNames.
+ * @alias RouterRouteNames
+ */
+export type RouteNames<T> = RouterRouteNames<T>;


### PR DESCRIPTION
## Summary

- Add short, provider-neutral type aliases alongside the existing `S3`-prefixed types
- Users on Cloudflare R2, MinIO, or other providers shouldn't need `S3*` names everywhere
- All old names remain 100% supported — no deprecation, purely additive

## New aliases

| Old (still works) | New alias |
|---|---|
| `S3Router` | `UploadRouter` |
| `S3UploadedFile` | `UploadedFile` |
| `S3RouteUploadResult` | `UploadResult` |
| `RouterRouteNames` | `RouteNames` |
| `S3FileConstraints` | `FileConstraints` |
| `S3LifecycleContext` | `LifecycleContext` |
| `S3LifecycleHook` | `LifecycleHook` |
| `S3Middleware` | `Middleware` |
| `S3MiddlewareContext` | `MiddlewareContext` |
| `S3RouteContext` | `RouteContext` |
| `S3RouterDefinition` | `RouterDefinition` |

## Before / After

**Before** (reads as AWS-specific):
```ts
import type { S3Router, S3LifecycleContext } from 'pushduck/server';
```

**After** (provider-neutral):
```ts
import type { UploadRouter, LifecycleContext } from 'pushduck/server';
```

## Test plan
- [x] All 156 tests pass
- [x] Type-check passes with no errors
- [x] Both old and new names resolve to identical types

🤖 Generated with [Claude Code](https://claude.com/claude-code)