### PR TITLE
feat(client): createUploadClient returns { upload, useUpload }

### DIFF
--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -320,4 +320,5 @@ export type {
   S3Router,
   TypedRouteHook,
   TypedUploadedFile,
+  UploadClientResult,
 } from "./types";

--- a/packages/pushduck/src/client/upload-client.ts
+++ b/packages/pushduck/src/client/upload-client.ts
@@ -31,8 +31,10 @@ import { useUploadRoute } from "../hooks/use-upload-route";
 import type {
   ClientConfig,
   InferClientRouter,
+  RouterRouteNames,
   S3Router,
   TypedRouteHook,
+  UploadClientResult,
   UploadRouteConfig,
 } from "../types";
 
@@ -210,8 +212,8 @@ function useTypedRoute<TRouter extends S3Router<any>>(
  */
 export function createUploadClient<TRouter extends S3Router<any>>(
   config: ClientConfig
-): InferClientRouter<TRouter> {
-  return new Proxy({} as any, {
+): UploadClientResult<TRouter> {
+  const upload = new Proxy({} as any, {
     get(target, prop) {
       if (typeof prop !== "string") {
         throw new Error(
@@ -219,8 +221,6 @@ export function createUploadClient<TRouter extends S3Router<any>>(
         );
       }
 
-      // Return a hook factory function that accepts optional route configuration
-      // This ensures hooks are called consistently on every render
       return (routeOptions?: UploadRouteConfig) =>
         useTypedRoute<TRouter>(prop, config, routeOptions);
     },
@@ -230,7 +230,6 @@ export function createUploadClient<TRouter extends S3Router<any>>(
     },
 
     ownKeys() {
-      // Return empty array since we don't know routes at runtime
       return [];
     },
 
@@ -239,10 +238,23 @@ export function createUploadClient<TRouter extends S3Router<any>>(
         return {
           enumerable: true,
           configurable: true,
-          get: () => this.get!(target, prop, target),
+          get: () => upload[prop],
         };
       }
       return undefined;
     },
   }) as InferClientRouter<TRouter>;
+
+  function useUpload<K extends RouterRouteNames<TRouter>>(
+    routeName: K,
+    routeOptions?: UploadRouteConfig
+  ): TypedRouteHook<TRouter, K extends string ? K : string> {
+    return useTypedRoute<TRouter>(
+      routeName as string,
+      config,
+      routeOptions
+    ) as TypedRouteHook<TRouter, K extends string ? K : string>;
+  }
+
+  return { upload, useUpload };
 }

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -223,8 +223,7 @@ export type { S3Router };
 export type RouterRouteNames<T> =
   T extends S3Router<infer TRoutes> ? keyof TRoutes : never;
 
-// Enhanced: Infer complete client interface from server router with optional configuration
-// Each route property returns a hook factory function that accepts optional configuration
+// Route proxy shape: each key is a hook factory
 export type InferClientRouter<T> =
   T extends S3Router<infer TRoutes>
   ? {
@@ -233,5 +232,29 @@ export type InferClientRouter<T> =
     ) => TypedRouteHook<T, K extends string ? K : string>;
   }
   : never;
+
+/**
+ * Return type of createUploadClient. Destructure to get both the proxy
+ * and a standalone typed hook:
+ *
+ * ```ts
+ * // lib/upload.ts
+ * export const { upload, useUpload } = createUploadClient<AppRouter>({ endpoint: '/api/upload' });
+ *
+ * // Component — no <AppRouter> needed, route name is still type-safe
+ * const { uploadFiles } = useUpload('imageUpload');
+ * // or use the proxy style (still works)
+ * const { uploadFiles } = upload.imageUpload();
+ * ```
+ */
+export type UploadClientResult<T extends S3Router<any>> = {
+  /** Route proxy — upload.routeName(options?) */
+  upload: InferClientRouter<T>;
+  /** Standalone typed hook — useUpload(routeName, options?) */
+  useUpload: <K extends RouterRouteNames<T>>(
+    routeName: K,
+    options?: RouteUploadOptions
+  ) => TypedRouteHook<T, K extends string ? K : string>;
+};
 
 // Legacy types removed - use TypedRouteHook and ClientConfig instead


### PR DESCRIPTION
## Summary

`createUploadClient` now returns `{ upload, useUpload }` instead of just the proxy, so you can define everything once and use it without repeating the router type in every component.

## Before

```ts
// lib/upload.ts
export const upload = createUploadClient<AppRouter>({ endpoint: '/api/upload' });

// Every component — generic needed every time
const { uploadFiles } = useUpload<AppRouter>('imageUpload');
```

## After

```ts
// lib/upload.ts — define once, type baked in
export const { upload, useUpload } = createUploadClient<AppRouter>({ endpoint: '/api/upload' });

// Every component — no generic, route name is still type-safe
const { uploadFiles } = useUpload('imageUpload');

// Proxy style still works too
const { uploadFiles } = upload.imageUpload();
```

## Test plan
- [x] All 156 tests pass
- [x] Type-check passes
- [x] `useUpload` route name argument is fully type-safe (autocomplete + error on unknown routes)
- [x] Old `upload.routeName()` proxy still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)