### PR TITLE
feat(schema): replace S3ImageSchema subclass with preset functions

### DIFF
--- a/packages/pushduck/src/__tests__/expires-in.test.ts
+++ b/packages/pushduck/src/__tests__/expires-in.test.ts
@@ -170,26 +170,26 @@ describe(".middleware() config preservation (regression)", () => {
     expect(route._getConfig().paths?.prefix).toBe("uploads");
   });
 
-  it("preserves onUploadComplete when .middleware() is called after", () => {
+  it("preserves onComplete when .middleware() is called after", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
     const route = s3
       .file()
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ userId: "123" }));
 
-    expect(route._getConfig().onUploadComplete).toBe(hook);
+    expect(route._getConfig().onComplete).toBe(hook);
   });
 
   it("preserves all config when multiple .middleware() calls are chained", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
-    // expiresIn and onUploadComplete start an S3Route; paths and further
+    // expiresIn and onComplete start an S3Route; paths and further
     // middleware calls must also preserve the accumulated config
     const route = s3
       .file()
       .expiresIn(600)
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ step: 1 }))
       .paths({ prefix: "docs" })
       .middleware(async ({ metadata }) => ({ ...metadata, step: 2 }));
@@ -197,7 +197,7 @@ describe(".middleware() config preservation (regression)", () => {
     const config = route._getConfig();
     expect(config.expiresIn).toBe(600);
     expect(config.paths?.prefix).toBe("docs");
-    expect(config.onUploadComplete).toBe(hook);
+    expect(config.onComplete).toBe(hook);
     expect(config.middleware).toHaveLength(2);
   });
 

--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -209,6 +209,9 @@ export { createUploadClient } from "./client/upload-client";
  * });
  * ```
  */
+// Preferred: hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================

--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -323,4 +323,9 @@ export type {
   S3Router,
   TypedRouteHook,
   TypedUploadedFile,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";

--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -159,15 +159,15 @@ function createS3Instance(config: UploadConfig) {
     file: (constraints?: S3FileConstraints) => new S3FileSchema(constraints),
 
     /**
-     * Preset: accepts any image (`image/*`).
-     * Equivalent to `upload.file().accept('image/*')`.
+     * `S3FileSchema` with `allowedTypes: ['image/*']` pre-set.
+     * Exactly `upload.file().accept('image/*')`.
      *
-     * Fully chainable — `.accept()` replaces the default wildcard if you need
-     * to narrow to specific formats:
+     * `.accept()` **replaces** the default — it does not merge.
+     * `upload.image().accept('image/jpeg')` → JPEG only, not `image/*` + JPEG.
      *
      * @example
      * ```ts
-     * upload.image()                                     // any image
+     * upload.image()                                      // any image (image/*)
      * upload.image().accept(['image/jpeg', 'image/webp']) // JPEG + WebP only
      * upload.image().maxSize('5MB').maxFiles(10)
      * ```
@@ -175,40 +175,48 @@ function createS3Instance(config: UploadConfig) {
     image: imagePreset,
 
     /**
-     * Preset: accepts any video (`video/*`).
-     * Equivalent to `upload.file().accept('video/*')`.
+     * `S3FileSchema` with `allowedTypes: ['video/*']` pre-set.
+     * Exactly `upload.file().accept('video/*')`.
+     *
+     * `.accept()` **replaces** the default.
+     * `upload.video().accept('video/mp4')` → MP4 only.
      *
      * @example
      * ```ts
-     * upload.video().maxSize('500MB')
-     * upload.video().accept(['video/mp4', 'video/webm']).maxFiles(3)
+     * upload.video()                                      // any video (video/*)
+     * upload.video().accept(['video/mp4', 'video/webm'])  // MP4 + WebM only
+     * upload.video().maxSize('500MB').maxFiles(3)
      * ```
      */
     video: videoPreset,
 
     /**
-     * Preset: accepts any audio (`audio/*`).
-     * Equivalent to `upload.file().accept('audio/*')`.
+     * `S3FileSchema` with `allowedTypes: ['audio/*']` pre-set.
+     * Exactly `upload.file().accept('audio/*')`.
+     *
+     * `.accept()` **replaces** the default.
+     * `upload.audio().accept('audio/mpeg')` → MP3 only.
      *
      * @example
      * ```ts
+     * upload.audio()                                      // any audio (audio/*)
+     * upload.audio().accept(['audio/mpeg', 'audio/wav'])  // MP3 + WAV only
      * upload.audio().maxSize('50MB')
-     * upload.audio().accept(['audio/mpeg', 'audio/wav'])
      * ```
      */
     audio: audioPreset,
 
     /**
-     * Preset: accepts common document formats
-     * (`.pdf`, `.doc`, `.docx`, `.txt`, `.csv`, `.xls`, `.xlsx`, `.ppt`, `.pptx`).
-     * Equivalent to `upload.file().accept(['.pdf', '.doc', ...])`.
+     * `S3FileSchema` with `allowedExtensions: ['pdf','doc','docx','txt','csv','xls','xlsx','ppt','pptx']` pre-set.
+     * Exactly `upload.file().accept(['.pdf', '.doc', '.docx', ...])`.
      *
-     * Use `.accept()` to narrow the allowed extensions further:
+     * `.accept()` **replaces** the default extension list entirely.
+     * `upload.document().accept(['.pdf'])` → PDFs only.
      *
      * @example
      * ```ts
-     * upload.document().maxSize('25MB')           // all doc formats
-     * upload.document().accept(['.pdf'])           // PDFs only
+     * upload.document()                      // pdf, doc, docx, txt, csv, xls, xlsx, ppt, pptx
+     * upload.document().accept(['.pdf'])     // PDFs only
      * upload.document().maxSize('10MB').maxFiles(5)
      * ```
      */

--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -628,13 +628,20 @@ export class UploadConfigBuilder {
     // Create storage instance with config
     const storage = createStorage(finalConfig);
 
-    // Create S3 builder instance with config
-    const s3 = createS3Instance(finalConfig);
+    // Create upload builder instance with config
+    const upload = createS3Instance(finalConfig);
 
     return {
       config: finalConfig,
       storage,
-      s3,
+      upload,
+      /** @deprecated Use `upload` instead. The `s3` name is misleading when using R2, MinIO, or other providers. */
+      get s3() {
+        console.warn(
+          '⚠️ pushduck: Destructuring `s3` from build() is deprecated. Use `upload` instead: const { upload } = createUploadConfig()...build()'
+        );
+        return upload;
+      },
     };
   }
 }
@@ -670,7 +677,12 @@ export interface UploadInitResult {
   config: UploadConfig;
   /** Storage instance for file operations (list, delete, info, etc.) */
   storage: StorageInstance;
-  /** S3 builder instance with schema builders and router factory */
+  /** Provider-neutral upload builder with schema builders and router factory */
+  upload: ReturnType<typeof createS3Instance>;
+  /**
+   * @deprecated Use `upload` instead.
+   * The `s3` name is misleading when using Cloudflare R2, MinIO, or other providers.
+   */
   s3: ReturnType<typeof createS3Instance>;
 }
 

--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -56,8 +56,11 @@ import { createS3RouterWithConfig, S3Route } from "../router/router-v2";
 import {
   S3FileConstraints,
   S3FileSchema,
-  S3ImageSchema,
   S3ObjectSchema,
+  audioPreset,
+  documentPreset,
+  imagePreset,
+  videoPreset,
 } from "../schema";
 import { createStorage, type StorageInstance } from "../storage/storage-api";
 import { logger } from "../utils/logger";
@@ -90,11 +93,7 @@ function smartCreateRouter<TRoutes extends Record<string, any>>(
   const convertedRoutes: Record<string, S3Route<any, any>> = {};
 
   for (const [key, value] of Object.entries(routes)) {
-    if (
-      value instanceof S3FileSchema ||
-      value instanceof S3ImageSchema ||
-      value instanceof S3ObjectSchema
-    ) {
+    if (value instanceof S3FileSchema || value instanceof S3ObjectSchema) {
       // Convert schema to route
       convertedRoutes[key] = new S3Route(value);
     } else {
@@ -121,67 +120,109 @@ function smartCreateRouter<TRoutes extends Record<string, any>>(
  *
  * @example
  * ```typescript
- * const { s3 } = createUploadConfig().provider("aws", {...}).build();
+ * const { upload } = createUploadConfig().provider("aws", {...}).build();
  *
- * // Use schema builders
- * const imageSchema = s3.image({ maxSize: '5MB' });
- * const fileSchema = s3.file({ allowedTypes: ['application/pdf'] });
+ * // Base schema — no type constraints
+ * upload.file().maxSize('10MB')
  *
- * // Create router with schemas
- * const router = s3.createRouter({
- *   avatarUpload: s3.image().maxFileSize('2MB'),
- *   documentUpload: s3.file({ maxSize: '10MB' }),
+ * // Named presets — accept() pre-filled, fully chainable
+ * upload.image().maxSize('5MB')
+ * upload.video().maxSize('500MB')
+ * upload.audio().maxSize('50MB')
+ * upload.document().maxSize('25MB')
+ *
+ * // Presets can be narrowed further with .accept()
+ * upload.image().accept(['image/jpeg', 'image/png'])
+ *
+ * // Build a router
+ * const router = upload.createRouter({
+ *   avatarUpload: upload.image().maxSize('2MB'),
+ *   resumeUpload: upload.document().accept(['.pdf']).maxSize('5MB'),
+ *   videoUpload:  upload.video().maxSize('100MB').maxFiles(3),
  * });
  * ```
  */
 function createS3Instance(config: UploadConfig) {
   return {
     /**
-     * Creates a file schema for general file uploads with optional constraints.
-     *
-     * @param constraints - Optional file validation constraints
-     * @returns A new S3FileSchema instance
+     * Base file schema — no type or size constraints pre-applied.
+     * Use this when no preset fits or you want full control.
      *
      * @example
-     * ```typescript
-     * const pdfSchema = s3.file({
-     *   maxSize: '10MB',
-     *   allowedTypes: ['application/pdf'],
-     * });
+     * ```ts
+     * upload.file()                           // unconstrained
+     * upload.file().accept('application/pdf') // PDFs only
+     * upload.file().maxSize('10MB')
+     * upload.file().accept(['.zip', '.tar']).maxSize('500MB')
      * ```
      */
     file: (constraints?: S3FileConstraints) => new S3FileSchema(constraints),
 
     /**
-     * Creates an image schema with image-specific validation and constraints.
+     * Preset: accepts any image (`image/*`).
+     * Equivalent to `upload.file().accept('image/*')`.
      *
-     * @param constraints - Optional image validation constraints
-     * @returns A new S3ImageSchema instance
+     * Fully chainable — `.accept()` replaces the default wildcard if you need
+     * to narrow to specific formats:
      *
      * @example
-     * ```typescript
-     * const avatarSchema = s3.image({
-     *   maxSize: '5MB',
-     *   allowedTypes: ['image/jpeg', 'image/png'],
-     * });
+     * ```ts
+     * upload.image()                                     // any image
+     * upload.image().accept(['image/jpeg', 'image/webp']) // JPEG + WebP only
+     * upload.image().maxSize('5MB').maxFiles(10)
      * ```
      */
-    image: (constraints?: S3FileConstraints) => new S3ImageSchema(constraints),
+    image: imagePreset,
 
     /**
-     * Creates an object schema for structured data validation.
-     *
-     * @template T - The shape of the object schema
-     * @param shape - Object defining the expected structure
-     * @returns A new S3ObjectSchema instance
+     * Preset: accepts any video (`video/*`).
+     * Equivalent to `upload.file().accept('video/*')`.
      *
      * @example
-     * ```typescript
-     * const metadataSchema = s3.object({
-     *   title: 'string',
-     *   tags: 'array',
-     *   userId: 'string',
-     * });
+     * ```ts
+     * upload.video().maxSize('500MB')
+     * upload.video().accept(['video/mp4', 'video/webm']).maxFiles(3)
+     * ```
+     */
+    video: videoPreset,
+
+    /**
+     * Preset: accepts any audio (`audio/*`).
+     * Equivalent to `upload.file().accept('audio/*')`.
+     *
+     * @example
+     * ```ts
+     * upload.audio().maxSize('50MB')
+     * upload.audio().accept(['audio/mpeg', 'audio/wav'])
+     * ```
+     */
+    audio: audioPreset,
+
+    /**
+     * Preset: accepts common document formats
+     * (`.pdf`, `.doc`, `.docx`, `.txt`, `.csv`, `.xls`, `.xlsx`, `.ppt`, `.pptx`).
+     * Equivalent to `upload.file().accept(['.pdf', '.doc', ...])`.
+     *
+     * Use `.accept()` to narrow the allowed extensions further:
+     *
+     * @example
+     * ```ts
+     * upload.document().maxSize('25MB')           // all doc formats
+     * upload.document().accept(['.pdf'])           // PDFs only
+     * upload.document().maxSize('10MB').maxFiles(5)
+     * ```
+     */
+    document: documentPreset,
+
+    /**
+     * Creates an object schema for multi-field structured uploads.
+     *
+     * @example
+     * ```ts
+     * upload.object({
+     *   avatar: upload.image().maxSize('2MB'),
+     *   resume: upload.document().accept(['.pdf']),
+     * })
      * ```
      */
     object: <T extends Record<string, any>>(shape: T) =>
@@ -189,26 +230,23 @@ function createS3Instance(config: UploadConfig) {
 
     /**
      * Creates a config-aware router with the provided route definitions.
-     * Routes can be schema objects or S3Route instances.
-     *
-     * @template TRoutes - The routes object type
-     * @param routes - Object mapping route names to schemas or routes
-     * @returns A configured S3Router instance
+     * Routes can be schema presets, `upload.file()` chains, or full `S3Route` instances.
      *
      * @example
      * ```typescript
-     * const router = s3.createRouter({
-     *   // Using schema builders
-     *   imageUpload: s3.image().maxFileSize('5MB'),
-     *   documentUpload: s3.file({ maxSize: '10MB' }),
+     * const router = upload.createRouter({
+     *   avatarUpload:   upload.image().maxSize('2MB'),
+     *   resumeUpload:   upload.document().accept(['.pdf']).maxSize('5MB'),
+     *   videoUpload:    upload.video().maxSize('100MB').maxFiles(3),
+     *   anyFile:        upload.file().maxSize('50MB'),
      *
-     *   // Using route with middleware
-     *   avatarUpload: s3.image()
-     *     .maxFileSize('2MB')
-     *     .middleware(async ({ metadata }) => ({
-     *       ...metadata,
-     *       userId: metadata.userId || 'anonymous',
-     *     })),
+     *   // With middleware (full route)
+     *   profilePic: upload.image()
+     *     .maxSize('2MB')
+     *     .middleware(async ({ req }) => {
+     *       const user = await getUser(req);
+     *       return { userId: user.id };
+     *     }),
      * });
      * ```
      */

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -411,8 +411,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   paths(paths: S3RoutePathConfig<TMetadata>): this {
-    this.config.paths = { ...this.config.paths, ...paths };
-    return this;
+    const newConfig = { ...this.config, paths: { ...this.config.paths, ...paths } };
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**
@@ -446,8 +446,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
         `expiresIn must be between 1 and 604800 seconds (7 days), got ${seconds}`
       );
     }
-    this.config.expiresIn = seconds;
-    return this;
+    const newConfig = { ...this.config, expiresIn: seconds };
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -463,8 +463,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   onUploadStart(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadStart = hook;
-    return this;
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return this.onStart(hook);
   }
 
   /**
@@ -473,34 +473,85 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    *
    * @param hook - Function to execute on upload progress
    * @returns This route instance for chaining
-   *
-   * @example Progress Tracking
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await updateUploadProgress(metadata.uploadId, {
-   *     fileName: file.name,
-   *     progress,
-   *     status: progress === 100 ? 'completing' : 'uploading',
-   *   });
-   * });
-   * ```
-   *
-   * @example Real-time Updates
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await sendProgressUpdate(metadata.userId, {
-   *     fileName: file.name,
-   *     percentComplete: progress,
-   *   });
-   * });
-   * ```
+   * @deprecated Use `.onProgress()` instead.
    */
   onUploadProgress(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { progress: number }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadProgress = hook;
+    console.warn('⚠️ pushduck: .onUploadProgress() is deprecated. Use .onProgress() instead.');
+    return this.onProgress(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   * Ideal for database updates, post-processing, and success notifications.
+   *
+   * @param hook - Function to execute on upload completion
+   * @returns This route instance for chaining
+   * @deprecated Use `.onComplete()` instead.
+   */
+  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return this.onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   * Essential for error logging, cleanup, and user notifications.
+   *
+   * @param hook - Function to execute on upload error
+   * @returns This route instance for chaining
+   * @deprecated Use `.onError()` instead.
+   */
+  onUploadError(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { error: Error }
+    ) => Promise<void> | void
+  ): this {
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return this.onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   * Useful for logging, initializing progress tracking, or sending notifications.
+   *
+   * @param hook - Function to execute on upload start
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onStart = hook;
+    return this;
+  }
+
+  /**
+   * Adds a hook that executes during file upload progress.
+   *
+   * @param hook - Function to execute on upload progress
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onProgress(async ({ file, metadata, progress }) => {
+   *   await updateUploadProgress(metadata.uploadId, { progress });
+   * });
+   * ```
+   */
+  onProgress(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { progress: number }
+    ) => Promise<void> | void
+  ): this {
+    this.config.onProgress = hook;
     return this;
   }
 
@@ -511,100 +562,37 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * @param hook - Function to execute on upload completion
    * @returns This route instance for chaining
    *
-   * @example Database Update
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, key, metadata }) => {
-   *   await db.files.create({
-   *     name: file.name,
-   *     size: file.size,
-   *     type: file.type,
-   *     url: url,
-   *     key: key,
-   *     uploadedBy: metadata.userId,
-   *     uploadedAt: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Post-processing
-   * ```typescript
-   * const route = s3.image().onUploadComplete(async ({ file, key, metadata }) => {
-   *   // Generate thumbnails for images
-   *   await generateThumbnails(key, {
-   *     sizes: [100, 300, 600],
-   *     userId: metadata.userId,
-   *   });
-   * });
-   * ```
-   *
-   * @example Notification System
-   * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_success',
-   *     message: `File "${file.name}" uploaded successfully`,
-   *     fileUrl: url,
-   *   });
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
    * });
    * ```
    */
-  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadComplete = hook;
+  onComplete(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onComplete = hook;
     return this;
   }
 
   /**
    * Adds a hook that executes when file upload fails.
-   * Essential for error logging, cleanup, and user notifications.
    *
    * @param hook - Function to execute on upload error
    * @returns This route instance for chaining
    *
-   * @example Error Logging
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   console.error(`Upload failed: ${file.name}`, error);
-   *   await logUploadError({
-   *     fileName: file.name,
-   *     error: error.message,
-   *     stack: error.stack,
-   *     userId: metadata.userId,
-   *     timestamp: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Cleanup and Retry
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   // Clean up any partial uploads
-   *   await cleanupPartialUpload(file.name, metadata.uploadId);
-   *
-   *   // Queue for retry if appropriate
-   *   if (isRetryableError(error)) {
-   *     await queueUploadRetry(file.name, metadata);
-   *   }
-   * });
-   * ```
-   *
-   * @example User Notification
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_error',
-   *     message: `Failed to upload "${file.name}": ${error.message}`,
-   *   });
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
    * });
    * ```
    */
-  onUploadError(
+  onError(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { error: Error }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadError = hook;
+    this.config.onError = hook;
     return this;
   }
 
@@ -636,14 +624,26 @@ interface S3RouteConfig<TMetadata = any> {
   /** Presigned upload URL expiration time in seconds (default: 3600 = 1 hour) */
   expiresIn?: number;
   /** Hook for upload start events */
-  onUploadStart?: S3LifecycleHook<TMetadata>;
+  onStart?: S3LifecycleHook<TMetadata>;
   /** Hook for upload progress events */
-  onUploadProgress?: (
+  onProgress?: (
     ctx: S3LifecycleContext<TMetadata> & { progress: number }
   ) => Promise<void> | void;
   /** Hook for upload completion events */
-  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  onComplete?: S3LifecycleHook<TMetadata>;
   /** Hook for upload error events */
+  onError?: (
+    ctx: S3LifecycleContext<TMetadata> & { error: Error }
+  ) => Promise<void> | void;
+  /** @deprecated Use onStart */
+  onUploadStart?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onProgress */
+  onUploadProgress?: (
+    ctx: S3LifecycleContext<TMetadata> & { progress: number }
+  ) => Promise<void> | void;
+  /** @deprecated Use onComplete */
+  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onError */
   onUploadError?: (
     ctx: S3LifecycleContext<TMetadata> & { error: Error }
   ) => Promise<void> | void;
@@ -885,9 +885,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           );
         }
 
-        // 3. Call onUploadStart hook
-        if (routeConfig.onUploadStart) {
-          await routeConfig.onUploadStart({ file, metadata: fileMetadata });
+        // 3. Call onStart hook (supports both new and deprecated name)
+        const onStartHook = routeConfig.onStart || routeConfig.onUploadStart;
+        if (onStartHook) {
+          await onStartHook({ file, metadata: fileMetadata });
         }
 
         // 4. Generate hierarchical file key
@@ -947,9 +948,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
             ? error
             : new Error("Failed to generate presigned URL");
 
-        // Call onUploadError hook with enriched metadata
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file,
             metadata: fileMetadata,
             error: err,
@@ -993,9 +995,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           3600
         );
 
-        // Call onUploadComplete hook
-        if (routeConfig.onUploadComplete) {
-          await routeConfig.onUploadComplete({
+        // Call onComplete hook (supports both new and deprecated name)
+        const onCompleteHook = routeConfig.onComplete || routeConfig.onUploadComplete;
+        if (onCompleteHook) {
+          await onCompleteHook({
             file: completion.file,
             metadata: completion.metadata || {},
             url,
@@ -1016,9 +1019,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
             ? error
             : new Error("Upload completion failed");
 
-        // Call onUploadError hook
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file: completion.file,
             metadata: completion.metadata || {},
             error: err,

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -141,10 +141,25 @@ export interface S3LifecycleContext<T = any> {
   file: S3FileMetadata;
   /** Processed metadata from middleware */
   metadata: T;
-  /** Public URL of the uploaded file (available after upload) */
-  url?: string;
-  /** Storage key/path of the uploaded file */
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public URL of the uploaded file. Never expires if bucket has public access.
+   * Store this in your database.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key?: string;
+  /** @deprecated Use `publicUrl` or `presignedUrl` instead. */
+  url?: string;
 }
 
 /**
@@ -1001,6 +1016,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           await onCompleteHook({
             file: completion.file,
             metadata: completion.metadata || {},
+            storagePath: completion.key,
+            publicUrl: url,
+            presignedUrl,
+            // deprecated aliases
             url,
             key: completion.key,
           });
@@ -1009,7 +1028,9 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
         results.push({
           success: true,
           key: completion.key,
+          storagePath: completion.key,
           url,
+          publicUrl: url,
           presignedUrl,
           file: completion.file,
         });
@@ -1062,9 +1083,16 @@ export interface UploadCompletion {
 
 export interface CompletionResponse {
   success: boolean;
+  /** Permanent storage path — store this in your database. */
+  storagePath?: string;
+  /** Public URL — store this in your database. */
+  publicUrl?: string;
+  /** Temporary presigned download URL — expires in ~1 hour, do not store. */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key: string;
+  /** @deprecated Use `publicUrl` or `presignedUrl` instead. */
   url?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
   file?: S3FileMetadata;
   error?: string;
 }

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -872,13 +872,36 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onStart()` instead.
+   */
   onUploadStart(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
       metadata: any;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadStart(hook);
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return new S3Route(this).onStart(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onStart(hook);
   }
 
   /**
@@ -916,6 +939,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onComplete()` instead.
+   */
   onUploadComplete(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -924,7 +950,29 @@ export class S3FileSchema extends S3Schema<File, File> {
       key?: string;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadComplete(hook);
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return new S3Route(this).onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
+   * });
+   * ```
+   */
+  onComplete(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      url?: string;
+      key?: string;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onComplete(hook);
   }
 
   /**
@@ -959,6 +1007,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onError()` instead.
+   */
   onUploadError(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -966,7 +1017,28 @@ export class S3FileSchema extends S3Schema<File, File> {
       error: Error;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadError(hook);
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return new S3Route(this).onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
+   * });
+   * ```
+   */
+  onError(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      error: Error;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onError(hook);
   }
 
   /**

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -1164,40 +1164,23 @@ export class S3FileSchema extends S3Schema<File, File> {
 // ========================================
 
 /**
- * Preset: accepts any image (MIME type `image/*`).
+ * `upload.image()` — `S3FileSchema` with `allowedTypes: ['image/*']` pre-set.
  *
- * Equivalent to `upload.file().accept('image/*')` — a named shortcut
- * so you don't have to remember the MIME wildcard.
+ * Exactly the same as writing `upload.file().accept('image/*')`.
+ * Returns a plain `S3FileSchema` — every chain method works identically.
  *
- * Fully chainable and overridable — all methods from `upload.file()` work:
+ * **Overriding**: `.accept()` replaces the default, it does not merge.
+ * `upload.image().accept('image/jpeg')` → only JPEG, not `image/*` + JPEG.
  *
- * @example Basic usage
+ * @example
  * ```ts
- * const router = upload.createRouter({
- *   avatar: upload.image().maxSize('2MB'),
- * });
- * ```
- *
- * @example Narrow to specific formats
- * ```ts
- * // .accept() replaces the default image/* with your list
- * upload.image().accept(['image/jpeg', 'image/png', 'image/webp'])
- * ```
- *
- * @example Gallery with a file cap
- * ```ts
- * upload.image().maxSize('5MB').maxFiles(10)
- * ```
- *
- * @example Full route with middleware
- * ```ts
+ * upload.image()                                      // any image (image/*)
+ * upload.image().accept(['image/jpeg', 'image/webp']) // JPEG + WebP only
+ * upload.image().maxSize('5MB').maxFiles(10)          // gallery, 10 images max
  * upload.image()
- *   .maxSize('5MB')
- *   .middleware(async ({ req }) => {
- *     const user = await getUser(req);
- *     return { userId: user.id };
- *   })
- *   .onComplete(async ({ file, storagePath, metadata }) => {
+ *   .maxSize('2MB')
+ *   .middleware(async ({ req }) => ({ userId: (await getUser(req)).id }))
+ *   .onComplete(async ({ storagePath, metadata }) => {
  *     await db.avatars.upsert({ userId: metadata.userId, path: storagePath });
  *   })
  * ```
@@ -1207,19 +1190,20 @@ export function imagePreset(constraints?: S3FileConstraints): S3FileSchema {
 }
 
 /**
- * Preset: accepts any video (MIME type `video/*`).
+ * `upload.video()` — `S3FileSchema` with `allowedTypes: ['video/*']` pre-set.
  *
- * Equivalent to `upload.file().accept('video/*')`.
+ * Exactly the same as writing `upload.file().accept('video/*')`.
+ * Returns a plain `S3FileSchema` — every chain method works identically.
+ *
+ * **Overriding**: `.accept()` replaces the default.
+ * `upload.video().accept('video/mp4')` → only MP4.
  *
  * @example
  * ```ts
+ * upload.video()                                       // any video (video/*)
+ * upload.video().accept(['video/mp4', 'video/webm'])   // MP4 + WebM only
  * upload.video().maxSize('500MB')
- *
- * // Narrow to specific codecs
- * upload.video().accept(['video/mp4', 'video/webm'])
- *
- * // Up to 3 videos, 100 MB each
- * upload.video().maxSize('100MB').maxFiles(3)
+ * upload.video().maxSize('100MB').maxFiles(3)          // up to 3 videos
  * ```
  */
 export function videoPreset(constraints?: S3FileConstraints): S3FileSchema {
@@ -1227,16 +1211,19 @@ export function videoPreset(constraints?: S3FileConstraints): S3FileSchema {
 }
 
 /**
- * Preset: accepts any audio (MIME type `audio/*`).
+ * `upload.audio()` — `S3FileSchema` with `allowedTypes: ['audio/*']` pre-set.
  *
- * Equivalent to `upload.file().accept('audio/*')`.
+ * Exactly the same as writing `upload.file().accept('audio/*')`.
+ * Returns a plain `S3FileSchema` — every chain method works identically.
+ *
+ * **Overriding**: `.accept()` replaces the default.
+ * `upload.audio().accept('audio/mpeg')` → only MP3.
  *
  * @example
  * ```ts
+ * upload.audio()                                       // any audio (audio/*)
+ * upload.audio().accept(['audio/mpeg', 'audio/wav'])   // MP3 + WAV only
  * upload.audio().maxSize('50MB')
- *
- * // Narrow to MP3 + WAV
- * upload.audio().accept(['audio/mpeg', 'audio/wav'])
  * ```
  */
 export function audioPreset(constraints?: S3FileConstraints): S3FileSchema {
@@ -1244,19 +1231,23 @@ export function audioPreset(constraints?: S3FileConstraints): S3FileSchema {
 }
 
 /**
- * Preset: accepts common document formats
- * (`.pdf`, `.doc`, `.docx`, `.txt`, `.csv`, `.xls`, `.xlsx`, `.ppt`, `.pptx`).
+ * `upload.document()` — `S3FileSchema` with `allowedExtensions` pre-set to common
+ * document formats: `pdf, doc, docx, txt, csv, xls, xlsx, ppt, pptx`.
  *
- * Equivalent to `upload.file().accept(['.pdf', '.doc', ...])`.
+ * Exactly the same as writing:
+ * ```ts
+ * upload.file().accept(['.pdf', '.doc', '.docx', '.txt', '.csv', '.xls', '.xlsx', '.ppt', '.pptx'])
+ * ```
+ * Returns a plain `S3FileSchema` — every chain method works identically.
+ *
+ * **Overriding**: `.accept()` replaces the default extension list entirely.
+ * `upload.document().accept(['.pdf'])` → PDFs only.
  *
  * @example
  * ```ts
+ * upload.document()                     // all doc formats listed above
+ * upload.document().accept(['.pdf'])    // PDFs only
  * upload.document().maxSize('25MB')
- *
- * // Narrow to PDFs only
- * upload.document().accept(['.pdf'])
- *
- * // Up to 5 documents
  * upload.document().maxSize('10MB').maxFiles(5)
  * ```
  */

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -1146,109 +1146,133 @@ export class S3FileSchema extends S3Schema<File, File> {
 }
 
 // ========================================
-// Image Schema Implementation
+// Preset Factory Functions
+// ========================================
+//
+// These are named shortcuts — each one is exactly upload.file() with a
+// sensible accept() pre-filled. They return plain S3FileSchema, so the
+// full chain (.accept, .maxSize, .minSize, .maxFiles, .middleware,
+// .onComplete, .paths, .expiresIn, …) works on all of them identically.
+//
+// Presets can be extended and overridden freely:
+//   upload.image()                      → accepts image/*
+//   upload.image().accept('image/jpeg') → narrows to JPEG only
+//   upload.image().maxSize('5MB')       → add a size limit
+//   upload.image().maxFiles(10)         → up to 10 images
+//   upload.image().middleware(...)      → add auth / path logic
+//
 // ========================================
 
-export class S3ImageSchema extends S3FileSchema {
-  constructor(constraints: S3FileConstraints = {}) {
-    // Default to image types if not specified
-    const imageConstraints = {
-      allowedTypes: ["image/*"],
-      ...constraints,
-    };
-    super(imageConstraints);
-  }
-
-  // Image-specific constraints
-  formats(formats: string[]): S3ImageSchema {
-    const mimeTypes = formats.map((format) => {
-      const mimeMap: Record<string, string> = {
-        jpg: "image/jpeg",
-        jpeg: "image/jpeg",
-        png: "image/png",
-        gif: "image/gif",
-        webp: "image/webp",
-        avif: "image/avif",
-        svg: "image/svg+xml",
-      };
-      return mimeMap[format.toLowerCase()] || `image/${format}`;
-    });
-
-    return new S3ImageSchema({ ...this.constraints, allowedTypes: mimeTypes });
-  }
-
-  // Override methods to maintain S3ImageSchema return type
-  /** @deprecated Use `.maxSize()` instead. */
-  override max(size: string | number): S3ImageSchema {
-    console.warn("⚠️ pushduck: .max() is deprecated. Use .maxSize() instead.");
-    return this.maxSize(size);
-  }
-
-  /** @deprecated Use `.maxSize()` instead. */
-  override maxFileSize(size: string | number): S3ImageSchema {
-    console.warn("⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead.");
-    return this.maxSize(size);
-  }
-
-  override maxSize(size: string | number): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, maxSize: size });
-  }
-
-  /** @deprecated Use `.minSize()` instead. */
-  override min(size: string | number): S3ImageSchema {
-    console.warn("⚠️ pushduck: .min() is deprecated. Use .minSize() instead.");
-    return this.minSize(size);
-  }
-
-  override minSize(size: string | number): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, minSize: size });
-  }
-
-  override accept(types: string | string[]): S3ImageSchema {
-    const typeArray = Array.isArray(types) ? types : [types];
-    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
-    const exts = typeArray.filter((t) => t.startsWith(".")).map((e) => e.slice(1));
-    const newConstraints = { ...this.constraints };
-    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
-    if (exts.length > 0) newConstraints.allowedExtensions = exts;
-    return new S3ImageSchema(newConstraints);
-  }
-
-  /** @deprecated Use `.accept()` instead. */
-  override types(allowedTypes: string[]): S3ImageSchema {
-    console.warn("⚠️ pushduck: .types() is deprecated. Use .accept() instead.");
-    return this.accept(allowedTypes);
-  }
-
-  /** @deprecated Use `.accept(['.ext'])` instead. */
-  override extensions(allowedExtensions: string[]): S3ImageSchema {
-    console.warn("⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead.");
-    return this.accept(allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`)));
-  }
-
-  /**
-   * Creates an array schema that validates multiple images with a maximum count.
-   * This is a convenience method for creating image arrays with a maximum file limit.
-   *
-   * @param maxCount - Maximum number of images allowed
-   * @returns New array schema instance with maximum constraint
-   *
-   * @example
-   * ```typescript
-   * const gallerySchema = s3.image()
-   *   .maxFileSize('2MB')
-   *   .formats(['jpeg', 'png'])
-   *   .maxFiles(6); // Maximum 6 images, each max 2MB
-   * ```
-   */
-  maxFiles(maxCount: number): S3ArraySchema<this> {
-    return new S3ArraySchema(this, { max: maxCount });
-  }
-
-  protected _clone(): this {
-    return new S3ImageSchema(this.constraints) as this;
-  }
+/**
+ * Preset: accepts any image (MIME type `image/*`).
+ *
+ * Equivalent to `upload.file().accept('image/*')` — a named shortcut
+ * so you don't have to remember the MIME wildcard.
+ *
+ * Fully chainable and overridable — all methods from `upload.file()` work:
+ *
+ * @example Basic usage
+ * ```ts
+ * const router = upload.createRouter({
+ *   avatar: upload.image().maxSize('2MB'),
+ * });
+ * ```
+ *
+ * @example Narrow to specific formats
+ * ```ts
+ * // .accept() replaces the default image/* with your list
+ * upload.image().accept(['image/jpeg', 'image/png', 'image/webp'])
+ * ```
+ *
+ * @example Gallery with a file cap
+ * ```ts
+ * upload.image().maxSize('5MB').maxFiles(10)
+ * ```
+ *
+ * @example Full route with middleware
+ * ```ts
+ * upload.image()
+ *   .maxSize('5MB')
+ *   .middleware(async ({ req }) => {
+ *     const user = await getUser(req);
+ *     return { userId: user.id };
+ *   })
+ *   .onComplete(async ({ file, storagePath, metadata }) => {
+ *     await db.avatars.upsert({ userId: metadata.userId, path: storagePath });
+ *   })
+ * ```
+ */
+export function imagePreset(constraints?: S3FileConstraints): S3FileSchema {
+  return new S3FileSchema({ allowedTypes: ["image/*"], ...constraints });
 }
+
+/**
+ * Preset: accepts any video (MIME type `video/*`).
+ *
+ * Equivalent to `upload.file().accept('video/*')`.
+ *
+ * @example
+ * ```ts
+ * upload.video().maxSize('500MB')
+ *
+ * // Narrow to specific codecs
+ * upload.video().accept(['video/mp4', 'video/webm'])
+ *
+ * // Up to 3 videos, 100 MB each
+ * upload.video().maxSize('100MB').maxFiles(3)
+ * ```
+ */
+export function videoPreset(constraints?: S3FileConstraints): S3FileSchema {
+  return new S3FileSchema({ allowedTypes: ["video/*"], ...constraints });
+}
+
+/**
+ * Preset: accepts any audio (MIME type `audio/*`).
+ *
+ * Equivalent to `upload.file().accept('audio/*')`.
+ *
+ * @example
+ * ```ts
+ * upload.audio().maxSize('50MB')
+ *
+ * // Narrow to MP3 + WAV
+ * upload.audio().accept(['audio/mpeg', 'audio/wav'])
+ * ```
+ */
+export function audioPreset(constraints?: S3FileConstraints): S3FileSchema {
+  return new S3FileSchema({ allowedTypes: ["audio/*"], ...constraints });
+}
+
+/**
+ * Preset: accepts common document formats
+ * (`.pdf`, `.doc`, `.docx`, `.txt`, `.csv`, `.xls`, `.xlsx`, `.ppt`, `.pptx`).
+ *
+ * Equivalent to `upload.file().accept(['.pdf', '.doc', ...])`.
+ *
+ * @example
+ * ```ts
+ * upload.document().maxSize('25MB')
+ *
+ * // Narrow to PDFs only
+ * upload.document().accept(['.pdf'])
+ *
+ * // Up to 5 documents
+ * upload.document().maxSize('10MB').maxFiles(5)
+ * ```
+ */
+export function documentPreset(constraints?: S3FileConstraints): S3FileSchema {
+  return new S3FileSchema({
+    allowedExtensions: ["pdf", "doc", "docx", "txt", "csv", "xls", "xlsx", "ppt", "pptx"],
+    ...constraints,
+  });
+}
+
+/**
+ * @deprecated `S3ImageSchema` is no longer a separate class.
+ * Use `upload.image()` or `upload.file().accept('image/*')` instead.
+ * This type alias is kept only for backward compatibility.
+ */
+export type S3ImageSchema = S3FileSchema;
 
 // ========================================
 // Array Schema Implementation
@@ -1437,7 +1461,10 @@ export class S3ObjectSchema<
 
 const s3 = {
   file: (constraints?: S3FileConstraints) => new S3FileSchema(constraints),
-  image: (constraints?: S3FileConstraints) => new S3ImageSchema(constraints),
+  image: imagePreset,
+  video: videoPreset,
+  audio: audioPreset,
+  document: documentPreset,
   object: <T extends Record<string, S3Schema>>(shape: T) =>
     new S3ObjectSchema(shape),
 } as const;

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -87,6 +87,13 @@ export interface S3FileConstraints {
   maxSize?: string | number;
   /** Minimum file size (string like '1KB' or number in bytes) */
   minSize?: string | number;
+  /**
+   * Accepted file types — mirrors HTML `<input accept>`.
+   * Supports MIME types (`'image/jpeg'`), wildcards (`'image/*'`),
+   * and extensions with dots (`'.pdf'`). Mixes are allowed.
+   * @example s3.file({ accept: ['image/*', '.pdf'] })
+   */
+  accept?: string | string[];
   /** Allowed MIME types (e.g., ['image/jpeg', 'application/pdf']) */
   allowedTypes?: string[];
   /** Allowed file extensions (e.g., ['.jpg', '.pdf']) */
@@ -589,6 +596,23 @@ export class S3FileSchema extends S3Schema<File, File> {
    */
   constructor(protected constraints: S3FileConstraints = {}) {
     super();
+    // Process `accept` shorthand into allowedTypes / allowedExtensions
+    if (constraints.accept) {
+      const acceptArray = Array.isArray(constraints.accept)
+        ? constraints.accept
+        : [constraints.accept];
+      const mimeTypes = acceptArray.filter((t) => !t.startsWith("."));
+      const exts = acceptArray
+        .filter((t) => t.startsWith("."))
+        .map((e) => e.slice(1)); // strip leading dot for internal storage
+      if (mimeTypes.length && !constraints.allowedTypes) {
+        constraints = { ...constraints, allowedTypes: mimeTypes };
+      }
+      if (exts.length && !constraints.allowedExtensions) {
+        constraints = { ...constraints, allowedExtensions: exts };
+      }
+      this.constraints = constraints;
+    }
     this._constraints = { ...constraints };
   }
 
@@ -688,11 +712,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
    * ```
    */
+  /** @deprecated Use `.maxSize()` instead. */
   max(size: string | number): S3FileSchema {
     console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
+      "⚠️ pushduck: .max() is deprecated. Use .maxSize() instead."
     );
-    return new S3FileSchema({ ...this.constraints, maxSize: size });
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  maxFileSize(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead."
+    );
+    return this.maxSize(size);
   }
 
   /**
@@ -703,12 +736,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().maxFileSize('10MB');
-   * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
+   * upload.file().maxSize('10MB')
+   * upload.file().maxSize(10485760) // 10MB in bytes
    * ```
    */
-  maxFileSize(size: string | number): S3FileSchema {
+  maxSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, maxSize: size });
+  }
+
+  /** @deprecated Use `.minSize()` instead. */
+  min(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .min() is deprecated. Use .minSize() instead."
+    );
+    return this.minSize(size);
   }
 
   /**
@@ -719,53 +760,54 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().min('1KB');
-   * const schema2 = s3.file().min(1024); // 1KB in bytes
+   * upload.file().minSize('1KB')
    * ```
    */
-  min(size: string | number): S3FileSchema {
+  minSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, minSize: size });
   }
 
   /**
-   * Sets the allowed MIME types constraint.
+   * Sets accepted file types — mirrors HTML `<input accept>`.
+   * Replaces `.types()` and `.extensions()` with a single unified method.
    *
-   * @param allowedTypes - Array of allowed MIME types
-   * @returns New schema instance with MIME type constraint
-   *
+   * Supports MIME types, wildcards, and extensions (with dots):
    * @example
    * ```typescript
-   * const imageSchema = s3.file().types([
-   *   'image/jpeg',
-   *   'image/png',
-   *   'image/webp'
-   * ]);
-   *
-   * const documentSchema = s3.file().types([
-   *   'application/pdf',
-   *   'application/msword',
-   *   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-   * ]);
+   * upload.file().accept('image/*')
+   * upload.file().accept(['image/jpeg', 'image/png'])
+   * upload.file().accept(['.pdf', '.doc'])
+   * upload.file().accept(['image/*', '.pdf']) // mixed
    * ```
    */
-  types(allowedTypes: string[]): S3FileSchema {
-    return new S3FileSchema({ ...this.constraints, allowedTypes });
+  accept(types: string | string[]): S3FileSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray
+      .filter((t) => t.startsWith("."))
+      .map((e) => e.slice(1)); // strip leading dot
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3FileSchema(newConstraints);
   }
 
-  /**
-   * Sets the allowed file extensions constraint.
-   *
-   * @param allowedExtensions - Array of allowed file extensions (with or without dots)
-   * @returns New schema instance with extension constraint
-   *
-   * @example
-   * ```typescript
-   * const imageSchema = s3.file().extensions(['.jpg', '.jpeg', '.png']);
-   * const docSchema = s3.file().extensions(['pdf', 'doc', 'docx']); // dots optional
-   * ```
-   */
+  /** @deprecated Use `.accept()` instead. */
+  types(allowedTypes: string[]): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .types() is deprecated. Use .accept() instead."
+    );
+    return this.accept(allowedTypes);
+  }
+
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   extensions(allowedExtensions: string[]): S3FileSchema {
-    return new S3FileSchema({ ...this.constraints, allowedExtensions });
+    console.warn(
+      "⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead, e.g. .accept([\'.pdf\', \'.doc\'])."
+    );
+    return this.accept(
+      allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`))
+    );
   }
 
   /**
@@ -1135,43 +1177,53 @@ export class S3ImageSchema extends S3FileSchema {
     return new S3ImageSchema({ ...this.constraints, allowedTypes: mimeTypes });
   }
 
-  // Override methods to maintain S3ImageSchema type
-  /**
-   * @deprecated Use `maxFileSize()` instead. This method will be removed in a future version.
-   */
+  // Override methods to maintain S3ImageSchema return type
+  /** @deprecated Use `.maxSize()` instead. */
   override max(size: string | number): S3ImageSchema {
-    console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
-    );
+    console.warn("⚠️ pushduck: .max() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  override maxFileSize(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  override maxSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, maxSize: size });
   }
 
-  /**
-   * Sets the maximum file size constraint.
-   *
-   * @param size - Maximum size as string (e.g., '10MB', '500KB') or number (bytes)
-   * @returns New schema instance with max size constraint
-   *
-   * @example
-   * ```typescript
-   * const schema = s3.image().maxFileSize('10MB');
-   * const schema2 = s3.image().maxFileSize(10485760); // 10MB in bytes
-   * ```
-   */
-  maxFileSize(size: string | number): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, maxSize: size });
-  }
-
+  /** @deprecated Use `.minSize()` instead. */
   override min(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .min() is deprecated. Use .minSize() instead.");
+    return this.minSize(size);
+  }
+
+  override minSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, minSize: size });
   }
 
-  override types(allowedTypes: string[]): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, allowedTypes });
+  override accept(types: string | string[]): S3ImageSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray.filter((t) => t.startsWith(".")).map((e) => e.slice(1));
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3ImageSchema(newConstraints);
   }
 
+  /** @deprecated Use `.accept()` instead. */
+  override types(allowedTypes: string[]): S3ImageSchema {
+    console.warn("⚠️ pushduck: .types() is deprecated. Use .accept() instead.");
+    return this.accept(allowedTypes);
+  }
+
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   override extensions(allowedExtensions: string[]): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, allowedExtensions });
+    console.warn("⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead.");
+    return this.accept(allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`)));
   }
 
   /**

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -665,13 +665,17 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
           }
         }
 
-        if (config.onSuccess) {
+        const successCallback = config.onComplete || config.onSuccess;
+        if (successCallback) {
+          if (config.onSuccess && !config.onComplete) {
+            console.warn('⚠️ pushduck: onSuccess is deprecated. Use onComplete instead.');
+          }
           setFiles((currentFiles) => {
             const finalFiles = currentFiles.filter(
               (f) => f.status === "success"
             );
             if (finalFiles.length > 0) {
-              config.onSuccess?.(finalFiles);
+              successCallback(finalFiles);
             }
             return currentFiles;
           });

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -468,10 +468,10 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
    * ```
    */
   const startUpload = useCallback(
-    async (uploadFiles: File[], metadata?: any) => {
+    async (uploadFiles: File[], metadata?: any): Promise<S3UploadedFile[]> => {
       if (!uploadFiles.length) {
         setIsUploading(false);
-        return;
+        return [];
       }
 
       try {
@@ -525,7 +525,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
           // Call onError callback for server errors
           config.onError?.(new Error(errorMessage));
-          return;
+          return [];
         }
 
         const presignData = await presignResponse.json();
@@ -545,7 +545,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
           // Call onError callback for presigned URL failures
           config.onError?.(new Error(errorMessage));
-          return;
+          return [];
         }
 
         // Upload validation passed - call onStart callback and initialize progress
@@ -619,6 +619,9 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
         const uploadResults = await Promise.all(uploadPromises);
         const successfulUploads = uploadResults.filter(Boolean);
 
+        // Track final completed files for the return value
+        const completedFiles: S3UploadedFile[] = [];
+
         if (successfulUploads.length > 0) {
           try {
             const completeResponse = await fetcher(
@@ -655,6 +658,15 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
                           url: result.url,
                           progress: 100,
                         });
+                        // Collect for return value
+                        completedFiles.push({
+                          ...fileToUpdate,
+                          status: "success",
+                          progress: 100,
+                          url: result.url,
+                          key: result.key,
+                          presignedUrl: result.presignedUrl,
+                        });
                       }
                     }
                   }
@@ -684,6 +696,8 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
             return currentFiles;
           });
         }
+
+        return completedFiles;
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : "Upload failed";
@@ -701,6 +715,7 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
         config.onError?.(
           error instanceof Error ? error : new Error(errorMessage)
         );
+        return [];
       } finally {
         setIsUploading(false);
         abortControllers.current.clear();

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -740,3 +740,33 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
 // Export utility functions for UI components
 export { formatETA, formatUploadSpeed };
+
+/**
+ * Hook for uploading files to a typed route.
+ * Preferred over `useUploadRoute` — hooks should look like hooks.
+ *
+ * @example
+ * ```typescript
+ * const { uploadFiles, files, isUploading } = useUpload<AppRouter>('imageUpload', {
+ *   onComplete: (results) => console.log('done', results),
+ * });
+ *
+ * const results = await uploadFiles(selectedFiles);
+ * ```
+ */
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter>,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload(
+  routeName: string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter> | string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult {
+  return useUploadRoute(routeName as string, config);
+}

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -588,7 +588,8 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
 
               updateFileStatus(fileState.id, "success", {
                 progress: 100,
-                key: result.key,
+                storagePath: result.key,
+                key: result.key, // deprecated alias
               });
 
               return {
@@ -646,9 +647,12 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
                       );
                       if (fileToUpdate) {
                         updateFileStatus(fileToUpdate.id, "success", {
-                          url: result.url,
-                          key: result.key,
+                          storagePath: result.key,
+                          publicUrl: result.url,
                           presignedUrl: result.presignedUrl,
+                          // deprecated aliases
+                          key: result.key,
+                          url: result.url,
                           progress: 100,
                         });
                       }

--- a/packages/pushduck/src/index.ts
+++ b/packages/pushduck/src/index.ts
@@ -9,7 +9,9 @@
 // HOOKS
 // ========================================
 
-// Main upload hook
+// Preferred upload hook — hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================

--- a/packages/pushduck/src/index.ts
+++ b/packages/pushduck/src/index.ts
@@ -42,6 +42,11 @@ export type {
   RouterRouteNames,
   S3Router,
   TypedRouteHook,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";
 
 // ========================================

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -198,10 +198,17 @@ export { createUploadConfig } from "./core/config/upload-config";
 export {
   S3ArraySchema,
   S3FileSchema,
-  S3ImageSchema,
   S3ObjectSchema,
   S3Schema,
+  // Preset functions — these are the preferred API
+  imagePreset,
+  videoPreset,
+  audioPreset,
+  documentPreset,
 } from "./core/schema";
+
+// S3ImageSchema is now just S3FileSchema — kept as a type alias for backward compat
+export type { S3ImageSchema } from "./core/schema";
 
 // ========================================
 // ROUTER SYSTEM

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -593,27 +593,114 @@ export type { LogLevel } from "./core/utils/logger";
 // ========================================
 // PROVIDER-NEUTRAL TYPE ALIASES
 // ========================================
+// All S3-prefixed originals remain fully supported — these are additive.
 
-// These aliases drop the "S3" prefix so they read naturally when using R2, MinIO, or any provider.
-// The S3-prefixed originals remain fully supported.
-
-export type {
-  UploadRouter,
-  UploadedFile,
-  UploadResult,
-  RouteNames,
-} from "./types";
-
-// Schema aliases
-export type { S3FileConstraints as FileConstraints } from "./core/schema";
-export type { InferS3Input as InferFileInput, InferS3Output as InferFileOutput } from "./core/schema";
-
-// Router/lifecycle aliases
-export type {
-  S3LifecycleContext as LifecycleContext,
-  S3LifecycleHook as LifecycleHook,
-  S3Middleware as Middleware,
-  S3MiddlewareContext as MiddlewareContext,
-  S3RouteContext as RouteContext,
-  S3RouterDefinition as RouterDefinition,
+import type { S3FileConstraints, InferS3Input, InferS3Output, S3Schema } from "./core/schema";
+import type {
+  S3LifecycleContext,
+  S3LifecycleHook,
+  S3Middleware,
+  S3MiddlewareContext,
+  S3RouteContext,
+  S3RouterDefinition,
 } from "./core/router/router-v2";
+
+// Re-export client-side aliases (JSDoc lives on the declarations in types/index.ts)
+export type { UploadRouter, UploadedFile, UploadResult, RouteNames } from "./types";
+
+/**
+ * Validation constraints for a file schema — `{ maxSize, minSize, allowedTypes, allowedExtensions }`.
+ *
+ * Same as `S3FileConstraints`. Can be passed directly to any preset or `upload.file()`:
+ * ```ts
+ * upload.file({ maxSize: '10MB', allowedTypes: ['application/pdf'] })
+ * // same as:
+ * upload.file().accept('application/pdf').maxSize('10MB')
+ * ```
+ */
+export type FileConstraints = S3FileConstraints;
+
+/**
+ * Infers the **input** type of a file schema (always `File` unless transformed).
+ *
+ * Same as `InferS3Input`:
+ * ```ts
+ * type Input = InferFileInput<typeof mySchema>; // File
+ * ```
+ */
+export type InferFileInput<T extends S3Schema> = InferS3Input<T>;
+
+/**
+ * Infers the **output** type of a file schema after any transforms.
+ *
+ * Same as `InferS3Output`:
+ * ```ts
+ * type Output = InferFileOutput<typeof mySchema>; // File (or custom transformed type)
+ * ```
+ */
+export type InferFileOutput<T extends S3Schema> = InferS3Output<T>;
+
+/**
+ * The context object passed to `.onStart()`, `.onComplete()`, `.onError()` lifecycle hooks.
+ *
+ * Same as `S3LifecycleContext`. Key fields:
+ * - `file` — `{ name, size, type }` of the uploaded file
+ * - `metadata` — server-side metadata returned from your `.middleware()`
+ * - `storagePath` — permanent key in the bucket (available in `onComplete`)
+ * - `publicUrl` — public URL if bucket is public (available in `onComplete`)
+ * - `presignedUrl` — temporary signed URL, ~1h (available in `onComplete`)
+ */
+export type LifecycleContext = S3LifecycleContext;
+
+/**
+ * A lifecycle hook function: `(ctx: LifecycleContext) => void | Promise<void>`.
+ *
+ * Same as `S3LifecycleHook`. Passed to `.onStart()`, `.onComplete()`, `.onError()`.
+ */
+export type LifecycleHook = S3LifecycleHook;
+
+/**
+ * A middleware function that runs before the upload and returns server-trusted metadata.
+ *
+ * Same as `S3Middleware`. Passed to `.middleware()`:
+ * ```ts
+ * upload.image().middleware(async ({ req, file, metadata }): Promise<{ userId: string }> => {
+ *   const user = await getUser(req);
+ *   if (!user) throw new Error('Unauthorized');
+ *   return { userId: user.id };
+ * })
+ * ```
+ */
+export type Middleware = S3Middleware;
+
+/**
+ * The context passed into a `.middleware()` function.
+ *
+ * Same as `S3MiddlewareContext`. Contains:
+ * - `req` — the incoming `Request`
+ * - `file` — `{ name, size, type }` of the file being uploaded
+ * - `metadata` — **untrusted** client-provided data from `uploadFiles(files, metadata)`
+ */
+export type MiddlewareContext = S3MiddlewareContext;
+
+/**
+ * Per-route context used internally during request handling.
+ *
+ * Same as `S3RouteContext`. Flows through middleware and lifecycle hooks automatically —
+ * you typically don't need to reference this type directly.
+ */
+export type RouteContext = S3RouteContext;
+
+/**
+ * The plain object shape passed to `upload.createRouter()`.
+ *
+ * Same as `S3RouterDefinition`. A record of route names to `S3Route` instances:
+ * ```ts
+ * const definition: RouterDefinition = {
+ *   avatar: upload.image().maxSize('2MB').middleware(...),
+ *   resume: upload.document().accept(['.pdf']),
+ * };
+ * const router = upload.createRouter(definition);
+ * ```
+ */
+export type RouterDefinition = S3RouterDefinition;

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -583,4 +583,30 @@ export type { HealthCheck, HealthCheckResult } from "./core/utils/health-check";
 
 export type { LogLevel } from "./core/utils/logger";
 
-// Legacy config types removed - use modern provider config types instead
+// ========================================
+// PROVIDER-NEUTRAL TYPE ALIASES
+// ========================================
+
+// These aliases drop the "S3" prefix so they read naturally when using R2, MinIO, or any provider.
+// The S3-prefixed originals remain fully supported.
+
+export type {
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
+} from "./types";
+
+// Schema aliases
+export type { S3FileConstraints as FileConstraints } from "./core/schema";
+export type { InferS3Input as InferFileInput, InferS3Output as InferFileOutput } from "./core/schema";
+
+// Router/lifecycle aliases
+export type {
+  S3LifecycleContext as LifecycleContext,
+  S3LifecycleHook as LifecycleHook,
+  S3Middleware as Middleware,
+  S3MiddlewareContext as MiddlewareContext,
+  S3RouteContext as RouteContext,
+  S3RouterDefinition as RouterDefinition,
+} from "./core/router/router-v2";

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -16,9 +16,31 @@ export interface S3UploadedFile {
   type: string;
   status: "pending" | "uploading" | "success" | "error";
   progress: number;
-  url?: string;
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public CDN URL if the bucket/provider has public access configured.
+   * Store this in your database — it never expires.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /**
+   * @deprecated Use `storagePath` instead. Will be removed in 1.0.0.
+   * The S3 object key — same value as storagePath.
+   */
   key?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
+  /**
+   * @deprecated Use `publicUrl` or `presignedUrl` instead. Will be removed in 1.0.0.
+   * Previously returned the public URL; now ambiguous with presignedUrl.
+   */
+  url?: string;
   error?: string;
   file?: File;
   // ETA tracking

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -274,26 +274,58 @@ export type InferClientRouter<T> =
 // ========================================
 
 /**
- * Provider-neutral alias for S3Router.
- * Works regardless of whether you use AWS S3, Cloudflare R2, MinIO, or any other provider.
- * @alias S3Router
+ * The router type returned by `upload.createRouter({ ... })`.
+ *
+ * Same as `S3Router` — alias exists so the type reads naturally when using
+ * Cloudflare R2, MinIO, or any provider other than AWS S3.
+ *
+ * Use this to annotate your exported router:
+ * ```ts
+ * import type { UploadRouter } from 'pushduck/server';
+ *
+ * export type AppRouter = typeof router;
+ * // AppRouter is UploadRouter<{ avatar: ..., resume: ... }>
+ * ```
  */
 export type UploadRouter<TRoutes extends Record<string, any> = Record<string, any>> = S3Router<TRoutes>;
 
 /**
- * Provider-neutral alias for S3UploadedFile.
- * @alias S3UploadedFile
+ * A single uploaded file with its status, URL, and storage path.
+ *
+ * Same as `S3UploadedFile`. Key fields:
+ * - `storagePath` — the permanent key in your bucket; **store this in your DB**
+ * - `publicUrl`   — permanent CDN/public URL (if your bucket is public)
+ * - `presignedUrl` — temporary signed URL (~1h); do **not** store this
+ * - `status`      — `'pending' | 'uploading' | 'success' | 'error'`
+ * - `progress`    — 0–100 upload progress
  */
 export type UploadedFile = S3UploadedFile;
 
 /**
- * Provider-neutral alias for S3RouteUploadResult.
- * @alias S3RouteUploadResult
+ * The object returned by `useUpload()` / `useUploadRoute()`.
+ *
+ * Same as `S3RouteUploadResult`. Contains:
+ * - `uploadFiles(files, metadata?)` — start the upload, returns `Promise<UploadedFile[]>`
+ * - `files`       — reactive array of `UploadedFile` with live progress
+ * - `isUploading` — `true` while any file is in flight
+ * - `errors`      — array of error messages from failed uploads
+ * - `progress`    — overall 0–100 progress across all files
+ * - `reset()`     — clear state and file list
  */
 export type UploadResult = S3RouteUploadResult;
 
 /**
- * Provider-neutral alias for RouterRouteNames.
- * @alias RouterRouteNames
+ * Union of all route names defined in a router.
+ *
+ * Same as `RouterRouteNames`. Use it to type a prop or variable that holds
+ * a route name:
+ * ```ts
+ * import type { RouteNames } from 'pushduck/client';
+ * import type { AppRouter } from '@/lib/upload';
+ *
+ * function UploadButton({ route }: { route: RouteNames<AppRouter> }) {
+ *   const { uploadFiles } = useUpload(route);
+ * }
+ * ```
  */
 export type RouteNames<T> = RouterRouteNames<T>;

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -114,7 +114,17 @@ export interface S3RouteUploadResult {
    * await uploadFiles(files, { albumId: '123', tags: ['vacation'] });
    * ```
    */
-  uploadFiles: (files: File[], metadata?: any) => Promise<void>;
+  /**
+   * Upload files and await the results directly.
+   * Returns the completed file objects — no need to watch `files` state or use `onSuccess`.
+   *
+   * @example
+   * ```typescript
+   * const results = await uploadFiles(selectedFiles);
+   * await db.save({ path: results[0].key });
+   * ```
+   */
+  uploadFiles: (files: File[], metadata?: any) => Promise<S3UploadedFile[]>;
 
   /** Reset upload state and clear files */
   reset: () => void;

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -269,4 +269,31 @@ export type InferClientRouter<T> =
   }
   : never;
 
-// Legacy types removed - use TypedRouteHook and ClientConfig instead
+// ========================================
+// Provider-Neutral Type Aliases
+// ========================================
+
+/**
+ * Provider-neutral alias for S3Router.
+ * Works regardless of whether you use AWS S3, Cloudflare R2, MinIO, or any other provider.
+ * @alias S3Router
+ */
+export type UploadRouter<TRoutes extends Record<string, any> = Record<string, any>> = S3Router<TRoutes>;
+
+/**
+ * Provider-neutral alias for S3UploadedFile.
+ * @alias S3UploadedFile
+ */
+export type UploadedFile = S3UploadedFile;
+
+/**
+ * Provider-neutral alias for S3RouteUploadResult.
+ * @alias S3RouteUploadResult
+ */
+export type UploadResult = S3RouteUploadResult;
+
+/**
+ * Provider-neutral alias for RouterRouteNames.
+ * @alias RouterRouteNames
+ */
+export type RouteNames<T> = RouterRouteNames<T>;

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -38,6 +38,9 @@ export interface UploadRouteConfig {
   endpoint?: string;
   fetcher?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
   onStart?: (files: S3FileMetadata[]) => void | Promise<void>;
+  /** Called when all uploads complete successfully. Preferred over onSuccess. */
+  onComplete?: (results: S3UploadedFile[]) => void | Promise<void>;
+  /** @deprecated Use onComplete instead. */
   onSuccess?: (results: S3UploadedFile[]) => void | Promise<void>;
   onError?: (error: Error) => void;
   onProgress?: (progress: number) => void;


### PR DESCRIPTION
## Summary

`S3ImageSchema` was a subclass of `S3FileSchema` with ~100 lines of method overrides that existed for one reason: so that `upload.image().maxSize()` returned `S3ImageSchema` instead of `S3FileSchema`. The class hierarchy was an implementation artifact, not a meaningful distinction.

Replace it with a family of named preset functions that are honest about what they are:

| Preset | Equivalent to |
|---|---|
| `upload.image()` | `upload.file().accept('image/*')` |
| `upload.video()` | `upload.file().accept('video/*')` |
| `upload.audio()` | `upload.file().accept('audio/*')` |
| `upload.document()` | `upload.file().accept(['.pdf', '.doc', '.docx', ...])` |

All presets return plain `S3FileSchema`. The entire chain works identically on all of them — no special cases, no overrides.

## Presets are fully chainable and overridable

```ts
// Narrow a preset's default accept
upload.image().accept(['image/jpeg', 'image/png', 'image/webp'])

// Add constraints on top
upload.image().maxSize('5MB').maxFiles(10)

// Full route with middleware
upload.image()
  .maxSize('5MB')
  .middleware(async ({ req }) => {
    const user = await getUser(req);
    return { userId: user.id };
  })
  .onComplete(async ({ storagePath, metadata }) => {
    await db.avatars.upsert({ userId: metadata.userId, path: storagePath });
  })

// Router with all presets
const router = upload.createRouter({
  avatar:    upload.image().maxSize('2MB'),
  reel:      upload.video().maxSize('500MB').maxFiles(3),
  podcast:   upload.audio().maxSize('100MB'),
  resume:    upload.document().accept(['.pdf']).maxSize('5MB'),
  anything:  upload.file().maxSize('50MB'),
});
```

## Backward compatibility

- `S3ImageSchema` kept as a deprecated type alias (`= S3FileSchema`) — existing type annotations still compile
- `.formats()` removed — use `.accept(['image/jpeg', 'image/png'])` instead (same thing, explicit)

## Test plan
- [x] All 156 tests pass
- [x] Type-check passes with no errors
- [x] `video`, `audio`, `document` presets added alongside `image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)