### PR TITLE
fix(providers): use nullish coalescing for config defaults

### DIFF
--- a/packages/pushduck/src/core/providers/providers.ts
+++ b/packages/pushduck/src/core/providers/providers.ts
@@ -438,9 +438,10 @@ function createProviderBuilder<T extends ProviderConfig>(
   return (config: Partial<T> = {}): T => {
     const result: any = { provider: spec.provider };
 
-    // Only use explicit config and defaults (no env vars)
+    // Only use explicit config and defaults (no env vars).
+    // Use ?? (nullish coalescing) so that false, 0, and "" are preserved.
     for (const [key] of Object.entries(spec.configKeys)) {
-      result[key] = config[key as keyof T] || spec.defaults[key] || "";
+      result[key] = config[key as keyof T] ?? spec.defaults[key] ?? "";
     }
 
     // Apply custom logic if provided


### PR DESCRIPTION
## What does this PR do?

Fixes `||` to `??` in the provider config builder. The `||` operator treats `false`, `0`, and `""` as falsy and falls through to defaults, silently overriding explicit user config:

```typescript
// Before: user sets forcePathStyle: false, but || treats it as falsy
result[key] = config[key] || spec.defaults[key] || "";
// forcePathStyle becomes "" (default), not false

// After: only null/undefined trigger fallback
result[key] = config[key] ?? spec.defaults[key] ?? "";
// forcePathStyle stays false
```

Affected configs:
- `forcePathStyle: false` — needed for virtual-hosted-style URLs (DigitalOcean Spaces, Backblaze B2)
- `useSSL: false` — needed for local MinIO without TLS
- Any boolean or numeric config value set to a falsy value

## How was it tested?

- All 172 tests pass
- Type-check clean