### PR TITLE
fix: correct broken docs examples, dead adapter exports, and tooling config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,19 @@ export default function Upload() {
 ### Storage Operations API
 
 ```typescript
-import { storage } from "pushduck/storage";
+import { createStorage, createUploadConfig } from "pushduck/server";
+
+const { config } = createUploadConfig()
+  .provider("aws", { bucket: "my-bucket", region: "us-east-1" })
+  .build();
+
+const storage = createStorage(config);
 
 // List files with filtering
 const files = await storage.list.files({
   prefix: "uploads/",
-  maxResults: 50,
-  sortBy: "lastModified"
+  maxFiles: 50,
+  sortBy: "modified"
 });
 
 // Get file metadata
@@ -155,8 +161,8 @@ await storage.delete.files(["file1.jpg", "file2.pdf"]); // Batch delete
 const downloadUrl = await storage.download.presignedUrl("uploads/document.pdf", 3600);
 
 // Advanced listing with pagination
-for await (const batch of storage.list.paginatedGenerator({ maxResults: 100 })) {
-  console.log(`Processing ${batch.files.length} files`);
+for await (const batch of storage.list.paginatedGenerator({ pageSize: 100 })) {
+  console.log(`Processing ${batch.length} files`);
   // Process large datasets efficiently
 }
 

--- a/packages/pushduck/package.json
+++ b/packages/pushduck/package.json
@@ -7,7 +7,7 @@
   "description": "Add file uploads to any web application. Secure, edge-ready. Works with 16+ frameworks and 5+ storage providers. No heavy AWS SDK required.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/abhay-ramesh/pushduck.git"
+    "url": "git+https://github.com/abhay-ramesh/pushduck.git"
   },
   "homepage": "https://pushduck.org",
   "bugs": {
@@ -82,9 +82,9 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "type-check": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage",
+    "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm build",

--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -591,7 +591,7 @@ export class UploadConfigBuilder {
    *   .build();
    *
    * // Use the storage instance
-   * const files = await storage.listFiles();
+   * const files = await storage.list.files();
    *
    * // Create routes with the s3 builder
    * const router = s3.createRouter({
@@ -658,8 +658,8 @@ export class UploadConfigBuilder {
  * console.log(config.provider.bucket); // "my-bucket"
  *
  * // Use storage operations
- * const files = await storage.listFiles();
- * const fileInfo = await storage.getFileInfo('path/to/file.jpg');
+ * const files = await storage.list.files();
+ * const fileInfo = await storage.metadata.getInfo('path/to/file.jpg');
  *
  * // Create typed routers
  * const router = s3.createRouter({

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -66,17 +66,18 @@
  *
  * @example Storage API Usage
  * ```typescript
- * import { createStorage, createProvider } from 'pushduck/server';
+ * import { createStorage, createUploadConfig } from 'pushduck/server';
  *
- * const storage = createStorage(createProvider('aws', {
- *   bucket: 'my-bucket',
- *   region: 'us-east-1',
- * }));
+ * const { config } = createUploadConfig()
+ *   .provider('aws', { bucket: 'my-bucket', region: 'us-east-1' })
+ *   .build();
  *
- * // High-level operations
- * const files = await storage.listFiles({ prefix: 'uploads/' });
- * const info = await storage.getFileInfo('uploads/document.pdf');
- * await storage.deleteFile('uploads/old-file.jpg');
+ * const storage = createStorage(config);
+ *
+ * // High-level operations, grouped by namespace
+ * const files = await storage.list.files({ prefix: 'uploads/' });
+ * const info = await storage.metadata.getInfo('uploads/document.pdf');
+ * await storage.delete.file('uploads/old-file.jpg');
  * ```
  *
  * @example Health Monitoring

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -254,9 +254,16 @@ export { createS3RouterWithConfig, S3Route } from "./core/router/router-v2";
  */
 export type { S3Router } from "./types";
 
-// Framework adapters - import from specific adapter modules
-// e.g. import { toNextJsHandler } from 'pushduck/adapters/nextjs'
-// e.g. import { toExpressHandler } from 'pushduck/adapters/express'
+// Framework adapters ship on a barrel and on per-adapter subpaths:
+//   import { toExpressHandler } from 'pushduck/adapters'          // preferred
+//   import { toExpressHandler } from 'pushduck/adapters/express'  // narrower types
+//
+// The barrel's types reference next, express and fastify. If you install only
+// one of them and set skipLibCheck: false, import the subpath instead so the
+// peers you do not have are never referenced.
+//
+// Frameworks that speak Web-standard Request/Response need no adapter at all —
+// use `router.handlers` directly.
 
 // ========================================
 // STORAGE API
@@ -266,41 +273,45 @@ export type { S3Router } from "./types";
  * High-level object-style storage API for direct file operations.
  * Provides a clean interface for file management without dealing with upload routes.
  *
+ * Operations are grouped into namespaces: `list`, `metadata`, `download`,
+ * `upload`, `validation` and `delete`.
+ *
  * @example Basic Storage Operations
  * ```typescript
- * import { createStorage, createProvider } from 'pushduck/server';
+ * import { createStorage, createUploadConfig } from 'pushduck/server';
  *
- * const storage = createStorage(createProvider('aws', {
- *   bucket: 'my-bucket',
- *   region: 'us-east-1',
- * }));
+ * const { config } = createUploadConfig()
+ *   .provider('aws', { bucket: 'my-bucket', region: 'us-east-1' })
+ *   .build();
+ *
+ * const storage = createStorage(config);
  *
  * // List files
- * const files = await storage.listFiles({ prefix: 'uploads/', limit: 50 });
+ * const files = await storage.list.files({ prefix: 'uploads/', maxFiles: 50 });
  *
  * // Get file information
- * const info = await storage.getFileInfo('uploads/document.pdf');
+ * const info = await storage.metadata.getInfo('uploads/document.pdf');
  * console.log(`File size: ${info.size}, Last modified: ${info.lastModified}`);
  *
  * // Delete files
- * await storage.deleteFile('uploads/old-file.jpg');
- * await storage.deleteFiles(['file1.jpg', 'file2.png']);
+ * await storage.delete.file('uploads/old-file.jpg');
+ * await storage.delete.files(['file1.jpg', 'file2.png']);
  * ```
  *
  * @example Advanced Storage Operations
  * ```typescript
- * // Generate presigned URLs for direct uploads
- * const presignedUrl = await storage.generatePresignedUploadUrl('uploads/new-file.pdf', {
+ * // Generate a presigned URL for a direct upload
+ * const { url, key } = await storage.upload.presignedUrl({
+ *   key: 'uploads/new-file.pdf',
+ *   contentType: 'application/pdf',
  *   expiresIn: 3600, // 1 hour
- *   conditions: {
- *     'content-type': 'application/pdf',
- *     'content-length-range': [0, 10485760], // Max 10MB
- *   },
  * });
  *
+ * // Generate a presigned URL for a download
+ * const downloadUrl = await storage.download.presignedUrl('uploads/new-file.pdf', 3600);
+ *
  * // Bulk operations
- * const deleteResult = await storage.deleteByPrefix('temp/');
- * console.log(`Deleted ${deleteResult.deletedCount} files`);
+ * const deleteResult = await storage.delete.byPrefix('temp/');
  * ```
  */
 export { createStorage, StorageInstance } from "./core/storage/storage-api";

--- a/packages/pushduck/tsdown.config.ts
+++ b/packages/pushduck/tsdown.config.ts
@@ -6,7 +6,16 @@ export default defineConfig({
     "src/server.ts",
     "src/client.ts",
     "src/react-native.ts",
+    // The barrel is the documented entry point, but each adapter is also
+    // published on its own subpath. The barrel's .d.ts references next,
+    // express and fastify types, so a project that installs only one of them
+    // and sets skipLibCheck: false gets TS2307 for the peers it lacks.
+    // Importing a single adapter avoids pulling in the others' types.
     "src/adapters/index.ts",
+    "src/adapters/nextjs.ts",
+    "src/adapters/nextjs-pages.ts",
+    "src/adapters/express.ts",
+    "src/adapters/fastify.ts",
   ],
   format: ["cjs", "esm"],
   dts: true,

--- a/packages/pushduck/vitest.config.ts
+++ b/packages/pushduck/vitest.config.ts
@@ -12,7 +12,15 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],
-      exclude: ["node_modules/", "dist/", "**/*.test.{ts,tsx}"],
+      // Without `include`, Vitest 3+ only reports files a test imported, so
+      // untested files vanish from the denominator instead of counting as 0%.
+      include: ["src/**"],
+      exclude: [
+        "node_modules/",
+        "dist/",
+        "**/*.test.{ts,tsx}",
+        "src/setupTests.ts",
+      ],
     },
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -54,9 +54,6 @@
     "clean": {
       "cache": false
     },
-    "type-check": {
-      "cache": false,
-      "persistent": true
-    }
+    "type-check": {}
   }
 }


### PR DESCRIPTION
Small, independently-verified fixes. Every item was reproduced as a real defect before being changed, and each fix was re-verified afterwards. No behavioural changes to the library itself.

## Adapter subpath exports — fixes #208

`package.json` advertised `./adapters/nextjs`, `./adapters/nextjs-pages`, `./adapters/express` and `./adapters/fastify`, but `tsdown.config.ts` only built the barrel. Those imports failed with `ERR_MODULE_NOT_FOUND` on both the published `0.6.0` and a fresh build of `main`.

Fixed by **building the four entries** rather than deleting the keys. The subpaths solve a problem the barrel cannot: the barrel's `.d.ts` references `next`, `next/server`, `express` and `fastify`, so a project that installs only one of those optional peers and sets `skipLibCheck: false` gets `TS2307` for the others.

Verified with an express-only consumer (no `next`, no `fastify`):

```
barrel  + skipLibCheck:false  ->  3x TS2307 (next/server, next, fastify)
subpath + skipLibCheck:false  ->  clean
```

Bundle size is not a reason to prefer either style — the adapters import their frameworks with `import type` only, so there is no runtime dependency, and esbuild tree-shakes unused adapters out of a barrel import entirely (1,384 bytes, no other adapter present).

Guidance added to `server.ts`: `pushduck/adapters` stays the recommended default; reach for a subpath when you have strict TS or only some of the peers.

## Tooling

- **`"test"` / `"test:coverage"` ran in watch mode.** Verified under a real TTY — `pnpm test` never exited (timeout exit code 124). Now `vitest run`. CI was unaffected because Vitest auto-detects `CI`, but it hung for contributors locally.
- **`coverage.include: ["src/**"]`.** Vitest 3+ dropped `coverage.all`, so files no test imported were omitted from the report instead of counting as 0%. Reported coverage was 46.72%; the honest number is **33.11%**, and `hooks/`, `adapters/`, `upload-client.ts` and `react-native.ts` now show as 0%. See #210.
- **`turbo.json`: dropped `"persistent": true` from `type-check`.** Verified it disabled caching — `type-check` took ~6s every run while `lint` hit FULL TURBO at 272ms. Now caches at 155ms.
- **`repository.url`** prefixed with `git+` per publint.

## Documentation

Both examples below were extracted into a real `.ts` file and compiled with `tsc` to confirm they are valid — the first attempt was not, which is how the `maxResults` error was caught.

- **`src/server.ts`** — the `createStorage` JSDoc documented an API that does not exist: a flat `storage.listFiles` / `getFileInfo` / `deleteFile` / `generatePresignedUploadUrl` surface, plus a `conditions` option with `content-length-range` that the library has no support for. The real API is namespaced (`storage.list.files`, `storage.delete.file`, …). It also passed `createProvider(...)` into `createStorage()`, which takes an `UploadConfig`. Rewritten against the actual surface.
- **`README.md`** — the Storage Operations example imported `{ storage } from "pushduck/storage"`. That subpath is not in the `exports` map and no `storage` singleton exists. Replaced with `createStorage(config)`. Also fixed `maxResults` → `maxFiles`, `sortBy: "lastModified"` → `"modified"` (valid values are `key | size | modified`), and `batch.files.length` → `batch.length` (`paginatedGenerator` yields `FileInfo[]`).
- **`src/server.ts`** adapters comment pointed at the unresolvable `pushduck/adapters/nextjs` specifier.

## Verification

```
publint:    12 errors -> 0   (11 warnings remain, all #207 CJS extensions)
tsc:        clean
eslint:     0 errors (186 pre-existing warnings)
build:      succeeds
tests:      172 passed
pnpm test:  exits cleanly under a TTY
all 5 adapter paths + pushduck/server resolve from a packed tarball
```

## Out of scope

- **#207** (CJS consumers cannot `require()` the package) — the 11 remaining publint warnings are all this. Separate change.
- **#168** (presigned download URL) — separate PR, with its failing tests.
- `PresignedUrlOptions.contentLength` is declared and set by the router at `router-v2.ts:932` but never used in signing. Left alone; it is evidence for a pending investigation into whether `maxFileSize` is enforceable at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated storage setup and usage examples to reflect the current API.
  * Clarified framework adapter import options and direct Web-standard handler usage.
  * Updated listing options, pagination, upload, download, and deletion examples.

* **Build & Testing**
  * Added separate build entry points for supported framework adapters.
  * Improved coverage reporting to include all source files.
  * Standardized test execution in non-watch mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->