### PR TITLE
fix: migrate pushduck.dev to pushduck.org (fixes failing docs deploys)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://pushduck.dev/docs
+    url: https://pushduck.org/docs
     about: Check the docs before filing — your answer might already be there
 
   - name: Discussions

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,7 @@ repository:
   # Repository basic settings
   name: pushduck
   description: "🦆 Simple, type-safe S3 uploads for Next.js with guided setup"
-  homepage: https://pushduck.dev
+  homepage: https://pushduck.org
   topics:
     - nextjs
     - s3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project and everyone participating in it is governed by our [Code of Conduc
 
 ## Getting Started
 
-Before contributing, please read our **[Philosophy & Scope](https://pushduck.dev/docs/philosophy)** to understand what Pushduck does (and doesn't do). This will help ensure your contribution aligns with the project's goals.
+Before contributing, please read our **[Philosophy & Scope](https://pushduck.org/docs/philosophy)** to understand what Pushduck does (and doesn't do). This will help ensure your contribution aligns with the project's goals.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue?style=flat&colorA=18181B&colorB=3178C6)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat&colorA=18181B&colorB=F59E0B)](https://opensource.org/licenses/MIT)
 [![CI/CD](https://img.shields.io/github/actions/workflow/status/abhay-ramesh/pushduck/ci.yml?style=flat&colorA=18181B&colorB=374151)](https://github.com/abhay-ramesh/pushduck/actions)
-[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289DA?style=flat&colorA=18181B&colorB=7289DA)](https://pushduck.dev/discord)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289DA?style=flat&colorA=18181B&colorB=7289DA)](https://pushduck.org/discord)
 [![Twitter](https://img.shields.io/badge/Twitter-Share%20on%20Twitter-1DA1F2?style=flat&colorA=18181B&colorB=1DA1F2)](https://twitter.com/intent/tweet?text=Just%20discovered%20%40pushduck%20-%20the%20fastest%20way%20to%20add%20file%20uploads%20to%20any%20web%20app!%20🦆%20https%3A//github.com/abhay-ramesh/pushduck)
 
 **Add file uploads to any web application. Secure, edge-ready.**
@@ -168,12 +168,12 @@ const recentFiles = await storage.list.byDate(new Date("2024-01-01"));
 
 ## Documentation
 
-- **[Getting Started](https://pushduck.dev/docs/quick-start)** - Complete setup guide
-- **[Philosophy & Scope](https://pushduck.dev/docs/philosophy)** - What we do (and don't do)
-- **[API Reference](https://pushduck.dev/docs/api)** - Full API documentation
-- **[Examples](https://pushduck.dev/docs/examples)** - Real-world examples
-- **[Providers](https://pushduck.dev/docs/providers)** - S3, R2, Spaces, MinIO
-- **[Security](https://pushduck.dev/docs/guides/security)** - Security best practices
+- **[Getting Started](https://pushduck.org/docs/quick-start)** - Complete setup guide
+- **[Philosophy & Scope](https://pushduck.org/docs/philosophy)** - What we do (and don't do)
+- **[API Reference](https://pushduck.org/docs/api)** - Full API documentation
+- **[Examples](https://pushduck.org/docs/examples)** - Real-world examples
+- **[Providers](https://pushduck.org/docs/providers)** - S3, R2, Spaces, MinIO
+- **[Security](https://pushduck.org/docs/guides/security)** - Security best practices
 
 ## Why Pushduck?
 
@@ -416,7 +416,7 @@ Built using:
   <strong>Built by <a href="https://github.com/abhay-ramesh">Abhay Ramesh</a></strong>
   <br>
   <a href="https://github.com/abhay-ramesh/pushduck">GitHub</a> •
-  <a href="https://pushduck.dev">Documentation</a> •
-  <a href="https://pushduck.dev/discord">Discord</a> •
+  <a href="https://pushduck.org">Documentation</a> •
+  <a href="https://pushduck.org/discord">Discord</a> •
   <a href="https://twitter.com/abhayramesh">Twitter</a>
 </div>

--- a/docs/app/docs-og/[...slug]/route.tsx
+++ b/docs/app/docs-og/[...slug]/route.tsx
@@ -12,7 +12,7 @@ export async function GET(
 
   // Fetch the mascot image
   const mascotImage = await fetch(
-    new URL("/pushduck-mascot.png", "https://pushduck.dev")
+    new URL("/pushduck-mascot.png", "https://pushduck.org")
   ).then((res) => res.arrayBuffer());
 
   return new ImageResponse(
@@ -161,7 +161,7 @@ export async function GET(
               display: "flex",
             }}
           >
-            pushduck.dev
+            pushduck.org
           </div>
         </div>
       </div>

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -30,11 +30,11 @@ export const metadata: Metadata = {
   ],
   authors: [{ name: "Abhay Ramesh" }],
   creator: "Abhay Ramesh",
-  metadataBase: new URL("https://pushduck.dev"),
+  metadataBase: new URL("https://pushduck.org"),
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://pushduck.dev",
+    url: "https://pushduck.org",
     title: "Pushduck - Simple S3 Uploads for Next.js",
     description: "Simple, type-safe S3 uploads for Next.js with guided setup",
     siteName: "Pushduck",

--- a/docs/app/og-image/route.tsx
+++ b/docs/app/og-image/route.tsx
@@ -3,7 +3,7 @@ import { ImageResponse } from "next/og";
 export async function GET() {
   // Fetch the mascot image
   const mascotImage = await fetch(
-    new URL("/pushduck-mascot.png", "https://pushduck.dev")
+    new URL("/pushduck-mascot.png", "https://pushduck.org")
   ).then((res) => res.arrayBuffer());
 
   return new ImageResponse(
@@ -154,7 +154,7 @@ export async function GET() {
               display: "flex",
             }}
           >
-            pushduck.dev
+            pushduck.org
           </div>
         </div>
       </div>

--- a/docs/content/docs/guides/client-approaches.mdx
+++ b/docs/content/docs/guides/client-approaches.mdx
@@ -557,4 +557,4 @@ The enhanced structured client adds zero runtime overhead while providing compil
 
 - **New Project**: Start with [createUploadClient](/docs/api/client/create-upload-client)
 - **Existing Hook Code**: Consider [migrating gradually](/docs/guides/migrate-to-enhanced-client)
-- **Need Help**: Join our [Discord community](https://pushduck.dev/discord) for guidance 
+- **Need Help**: Join our [Discord community](https://pushduck.org/discord) for guidance 

--- a/docs/content/docs/guides/migrate-to-enhanced-client.mdx
+++ b/docs/content/docs/guides/migrate-to-enhanced-client.mdx
@@ -463,5 +463,5 @@ const propertyUpload = upload.imageUpload;
 <Callout type="success">
   **Migration Complete!** You now have enhanced type safety and a better
   developer experience. Need help? Join our [Discord
-  community](https://pushduck.dev/discord) for support.
+  community](https://pushduck.org/discord) for support.
 </Callout>

--- a/docs/content/docs/manual-setup.mdx
+++ b/docs/content/docs/manual-setup.mdx
@@ -313,7 +313,7 @@ Now that you have the basics working, explore these advanced features:
 ## Need Help?
 
 - **Documentation**: Explore our comprehensive [guides](/docs/guides)
-- **Community**: Join our [Discord community](https://pushduck.dev/discord)
+- **Community**: Join our [Discord community](https://pushduck.org/discord)
 - **Issues**: Report bugs on [GitHub](https://github.com/abhay-ramesh/pushduck)
 - **Support**: Email us at support@pushduck.com
 

--- a/docs/content/docs/philosophy.mdx
+++ b/docs/content/docs/philosophy.mdx
@@ -761,7 +761,7 @@ When considering new features, we ask:
 Have questions about scope or philosophy?
 
 - 💭 [GitHub Discussions](https://github.com/abhay-ramesh/pushduck/discussions)
-- 💬 [Discord Community](https://pushduck.dev/discord)
+- 💬 [Discord Community](https://pushduck.org/discord)
 - 🐛 [GitHub Issues](https://github.com/abhay-ramesh/pushduck/issues)
 
 <Callout type="success">

--- a/docs/content/docs/providers/aws-s3.mdx
+++ b/docs/content/docs/providers/aws-s3.mdx
@@ -493,4 +493,4 @@ Now that AWS S3 is configured, explore these advanced features:
 
 ---
 
-**Need help with AWS S3 setup?** Join our [Discord community](https://pushduck.dev/discord) or check out the [troubleshooting guide](/docs/api/troubleshooting) for common issues.
+**Need help with AWS S3 setup?** Join our [Discord community](https://pushduck.org/discord) or check out the [troubleshooting guide](/docs/api/troubleshooting) for common issues.

--- a/docs/lib/metadata.ts
+++ b/docs/lib/metadata.ts
@@ -1,4 +1,4 @@
 export const baseUrl =
   process.env.NODE_ENV === "development"
     ? new URL("http://localhost:3000")
-    : new URL("https://pushduck.dev");
+    : new URL("https://pushduck.org");

--- a/packages/cli/src/commands/add-component.ts
+++ b/packages/cli/src/commands/add-component.ts
@@ -32,7 +32,7 @@ interface Registry {
   }>;
 }
 
-const REGISTRY_BASE_URL = "https://pushduck.dev/r";
+const REGISTRY_BASE_URL = "https://pushduck.org/r";
 
 export async function addComponentCommand(componentName?: string) {
   try {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,7 +26,7 @@ function getCORSLinks(provider: ProviderType): {
   corsSetup: string;
   providerDocs: string;
 } {
-  const baseUrl = "https://pushduck.dev";
+  const baseUrl = "https://pushduck.org";
 
   switch (provider) {
     case "aws":
@@ -104,22 +104,22 @@ export async function initCommand(options: InitOptions = {}) {
       );
 
       console.log(chalk.cyan("Manual Setup Documentation:"));
-      console.log("  https://pushduck.dev/docs/getting-started/manual-setup");
+      console.log("  https://pushduck.org/docs/getting-started/manual-setup");
 
       console.log(chalk.cyan("\nIntegration Guides:"));
 
       // Show specific framework integration if detected
       if (projectInfo.framework === "react") {
-        console.log("  React: https://pushduck.dev/docs/integrations/overview");
+        console.log("  React: https://pushduck.org/docs/integrations/overview");
       } else if (projectInfo.framework === "vue") {
-        console.log("  Vue: https://pushduck.dev/docs/integrations/overview");
+        console.log("  Vue: https://pushduck.org/docs/integrations/overview");
       } else if (projectInfo.framework === "svelte") {
         console.log(
-          "  Svelte: https://pushduck.dev/docs/integrations/overview"
+          "  Svelte: https://pushduck.org/docs/integrations/overview"
         );
       } else {
         console.log(
-          "  General: https://pushduck.dev/docs/integrations/overview"
+          "  General: https://pushduck.org/docs/integrations/overview"
         );
       }
 
@@ -365,7 +365,7 @@ export async function initCommand(options: InitOptions = {}) {
       console.log("  3. Build your upload interface!");
     }
 
-    console.log(chalk.cyan("\n📚 Documentation: https://pushduck.dev/docs"));
+    console.log(chalk.cyan("\n📚 Documentation: https://pushduck.org/docs"));
 
     // Step 10: Test configuration
     if (credentials.accessKeyId && credentials.secretAccessKey) {
@@ -439,7 +439,7 @@ export async function initCommand(options: InitOptions = {}) {
 
     console.log(
       chalk.gray(
-        "\nFor help, visit: https://pushduck.dev/docs/api/troubleshooting"
+        "\nFor help, visit: https://pushduck.org/docs/api/troubleshooting"
       )
     );
     process.exit(1);

--- a/packages/cli/src/utils/provider-setup.ts
+++ b/packages/cli/src/utils/provider-setup.ts
@@ -168,7 +168,7 @@ export async function selectProvider(
   console.log(chalk.blue("Why " + selectedInfo.name + "?"));
   console.log(chalk.gray("   • " + selectedInfo.description));
   console.log(
-    chalk.gray("   • Need help choosing? https://pushduck.dev/docs/providers\n")
+    chalk.gray("   • Need help choosing? https://pushduck.org/docs/providers\n")
   );
 
   return provider;

--- a/packages/pushduck/README.md
+++ b/packages/pushduck/README.md
@@ -9,7 +9,7 @@
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289DA?style=flat&colorA=18181B&colorB=7289DA)](https://discord.gg/pushduck)
 [![Twitter](https://img.shields.io/badge/Twitter-Share%20on%20Twitter-1DA1F2?style=flat&colorA=18181B&colorB=1DA1F2)](https://twitter.com/intent/tweet?text=Just%20discovered%20%40pushduck%20-%20the%20fastest%20way%20to%20add%20file%20uploads%20to%20any%20web%20app!%20🦆%20https%3A//github.com/abhay-ramesh/pushduck)
 
-![](https://pushduck.dev/banner.png)
+![](https://pushduck.org/banner.png)
 
 **Pushduck** is a type-safe file upload library for Next.js applications with S3-compatible storage providers. Built with modern React patterns and comprehensive TypeScript support.
 
@@ -515,7 +515,7 @@ MINIO_SECRET_ACCESS_KEY=your_secret_key
 
 ## Migration Guide
 
-If you're upgrading from an older version, see our [Migration Guide](https://pushduck.dev/docs/guides/migration) for step-by-step instructions.
+If you're upgrading from an older version, see our [Migration Guide](https://pushduck.org/docs/guides/migration) for step-by-step instructions.
 
 ## Contributing
 
@@ -527,6 +527,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-- **Documentation**: [pushduck.dev](https://pushduck.dev)
+- **Documentation**: [pushduck.org](https://pushduck.org)
 - **Issues**: [GitHub Issues](https://github.com/abhay-ramesh/pushduck/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/abhay-ramesh/pushduck/discussions)

--- a/packages/pushduck/package.json
+++ b/packages/pushduck/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/abhay-ramesh/pushduck.git"
   },
-  "homepage": "https://pushduck.dev",
+  "homepage": "https://pushduck.org",
   "bugs": {
     "url": "https://github.com/abhay-ramesh/pushduck/issues"
   },

--- a/packages/pushduck/src/client/upload-client.ts
+++ b/packages/pushduck/src/client/upload-client.ts
@@ -205,8 +205,8 @@ function useTypedRoute<TRouter extends S3Router<any>>(
  * });
  * ```
  *
- * @see {@link https://pushduck.dev/docs/api/client/create-upload-client} for complete documentation
- * @see {@link https://pushduck.dev/docs/guides/advanced/client-metadata} for metadata guide
+ * @see {@link https://pushduck.org/docs/api/client/create-upload-client} for complete documentation
+ * @see {@link https://pushduck.org/docs/guides/advanced/client-metadata} for metadata guide
  */
 export function createUploadClient<TRouter extends S3Router<any>>(
   config: ClientConfig

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -237,12 +237,12 @@ Components require these peer dependencies:
 
 ## Registry URL
 
-Components are served from: `https://pushduck.dev/r/[component-name].json`
+Components are served from: `https://pushduck.org/r/[component-name].json`
 
 Example:
 
-- <https://pushduck.dev/r/upload-dropzone.json>
-- <https://pushduck.dev/r/file-list.json>
+- <https://pushduck.org/r/upload-dropzone.json>
+- <https://pushduck.org/r/file-list.json>
 
 ## Development
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/abhay-ramesh/pushduck.git",
         "directory": "packages/ui"
     },
-    "homepage": "https://pushduck.dev",
+    "homepage": "https://pushduck.org",
     "keywords": [
         "react",
         "components",

--- a/packages/ui/public/r/index.json
+++ b/packages/ui/public/r/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "pushduck",
-  "homepage": "https://pushduck.dev",
+  "homepage": "https://pushduck.org",
   "items": [
     {
       "name": "upload-dropzone",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://ui.shadcn.com/schema/registry.json",
     "name": "pushduck",
-    "homepage": "https://pushduck.dev",
+    "homepage": "https://pushduck.org",
     "items": [
         {
             "name": "upload-dropzone",


### PR DESCRIPTION
`pushduck.dev` has been shut down. It is NXDOMAIN, which breaks the docs deploy, the production OG image route, and every published link.

```
pushduck.dev  ->  NXDOMAIN
pushduck.org  ->  200   (apex is canonical; www redirects to it)
```

## This is why Vercel deploys are failing

Not a recent code change. Both OG routes fetch the mascot from the hardcoded domain at build time, so `next build` dies during static generation:

```
Error occurred prerendering page "/docs-og/ai-integration/image.png"
TypeError: fetch failed
  [cause]: Error: getaddrinfo ENOTFOUND pushduck.dev
Export encountered an error on /docs-og/[...slug]/route, exiting the build.
```

Production is affected too — `https://pushduck.org/og-image` currently returns **500**, and the deployed site still advertises `og:url = https://pushduck.dev`.

## What changed

46 URL references across 23 files: both OG routes, `metadataBase` and `og:url` in the docs layout and metadata lib, the CLI's registry base URL and its printed help links, package `homepage` fields, the UI registry, and docs/README/CONTRIBUTING links.

Every endpoint was checked on the new domain before switching:

| Path | Status |
|---|---|
| `/discord` | 200 |
| `/banner.png` | 200 |
| `/docs/philosophy` | 200 |
| `/docs/quick-start` | 200 |
| `/pushduck-mascot.png` | 200 |

## Deliberately NOT changed — needs a decision

The five `@pushduck.dev` email addresses in `CODE_OF_CONDUCT.md` and the two `CONTRIBUTING.md` files are left alone:

```
pushduck.org has no MX record
```

Rewriting them would swap five dead addresses for five *different* dead addresses while looking fixed. `security@`, `conduct@` and `hello@` need a real destination decided first. For the security contact specifically, GitHub Security Advisories may be a better answer than an email address.

## Known still-broken, out of scope

The CLI component registry 404s on the new domain:

```
/r/index.json             404
/r/upload-dropzone.json   404
```

`pushduck add <component>` is broken regardless of which domain it points at, because the registry is not served there. This PR updates the URL for consistency but does not fix it — the registry needs to be deployed, or the command retired.

## Note on #211

The Vercel check on #211 fails for this same reason. It should go green once this merges.
