### PR TITLE
fix(tests): use native File/Blob/fetch/AbortController instead of stubs

### DIFF
--- a/packages/pushduck/src/__tests__/chain-validation.test.ts
+++ b/packages/pushduck/src/__tests__/chain-validation.test.ts
@@ -12,13 +12,13 @@ describe("Schema chaining — actual validation", () => {
       })
       .build().s3;
 
-  // Helper: create a File with a specific size
-  const makeFile = (name: string, type: string, sizeBytes: number) => {
-    const f = new File([new ArrayBuffer(sizeBytes)], name, { type });
-    // File constructor may not respect exact size, so override
-    Object.defineProperty(f, "size", { value: sizeBytes });
-    return f;
-  };
+  // Helper: create a File with a specific size.
+  // The real File constructor reports byte length accurately, so no override
+  // is needed. The previous `Object.defineProperty(f, "size", ...)` worked
+  // around the old MockFile, which summed `parts.length` and so produced NaN
+  // for an ArrayBuffer part.
+  const makeFile = (name: string, type: string, sizeBytes: number) =>
+    new File([new ArrayBuffer(sizeBytes)], name, { type });
 
   it("maxFileSize rejects files that are too large", async () => {
     const s3 = buildS3();

--- a/packages/pushduck/src/__tests__/test-harness.test.ts
+++ b/packages/pushduck/src/__tests__/test-harness.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Guards the integrity of the test harness itself.
+ *
+ * `setupTests.ts` previously replaced File, Blob, fetch and AbortController
+ * with hand-written stubs. Those stubs were wrong in ways that let real bugs
+ * pass — most importantly `MockFile.size` summed `parts.length`, producing
+ * character counts for strings and NaN for ArrayBuffer/Blob parts. Since
+ * `NaN > limit` is false, an oversized file passed a maxFileSize check.
+ *
+ * Every assertion here fails under those stubs. If someone reintroduces a
+ * global stub, this file goes red rather than the suite quietly lying.
+ */
+import { describe, expect, it } from "vitest";
+
+describe("test harness integrity", () => {
+  describe("File reports real byte lengths", () => {
+    it("counts UTF-8 bytes, not characters", () => {
+      // Old MockFile: 5 (string length). Real: 6 (é is two bytes).
+      expect(new File(["héllo"], "a.txt").size).toBe(6);
+      // Old MockFile: 2 (UTF-16 code units). Real: 4.
+      expect(new File(["👋"], "b.txt").size).toBe(4);
+    });
+
+    it("handles ArrayBuffer parts", () => {
+      // Old MockFile: NaN — ArrayBuffer has byteLength, not length.
+      expect(new File([new ArrayBuffer(1024)], "c.bin").size).toBe(1024);
+    });
+
+    it("handles Blob parts", () => {
+      // Old MockFile: NaN — Blob has size, not length.
+      expect(new File([new Blob(["12345"])], "d.bin").size).toBe(5);
+    });
+
+    it("sums mixed parts", () => {
+      const f = new File(["ab", new ArrayBuffer(3), new Blob(["cd"])], "e.bin");
+      expect(f.size).toBe(2 + 3 + 2);
+    });
+
+    it("does not let an oversized file pass a size check", () => {
+      const limit = 1_000_000;
+      const oversized = new File([new ArrayBuffer(2_000_000)], "big.bin");
+      // The bug this guards: NaN > limit === false, so this read as "under limit".
+      expect(Number.isNaN(oversized.size)).toBe(false);
+      expect(oversized.size > limit).toBe(true);
+    });
+  });
+
+  describe("globals are the real implementations", () => {
+    it("exposes the real File API surface", async () => {
+      const f = new File(["abc"], "f.txt", { type: "text/plain" });
+      expect(typeof f.arrayBuffer).toBe("function");
+      expect(typeof f.text).toBe("function");
+      expect(await f.text()).toBe("abc");
+      expect(f.type).toBe("text/plain");
+    });
+
+    it("Blob exposes its real API", async () => {
+      const b = new Blob(["hello"], { type: "text/plain" });
+      expect(b.size).toBe(5);
+      expect(await b.text()).toBe("hello");
+    });
+
+    it("AbortController actually notifies listeners", () => {
+      // Old MockAbortController: addEventListener was vi.fn(), so this stayed false.
+      const ac = new AbortController();
+      let fired = false;
+      ac.signal.addEventListener("abort", () => {
+        fired = true;
+      });
+      ac.abort();
+      expect(fired).toBe(true);
+      expect(ac.signal.aborted).toBe(true);
+    });
+
+    it("fetch is not globally stubbed", () => {
+      // Old setup: `global.fetch = vi.fn()` for every test, unconditionally.
+      // Tests that need a fake fetch should stub it themselves.
+      expect((globalThis.fetch as unknown as { _isMockFunction?: boolean })._isMockFunction).toBeUndefined();
+    });
+  });
+});

--- a/packages/pushduck/src/setupTests.ts
+++ b/packages/pushduck/src/setupTests.ts
@@ -1,83 +1,37 @@
-import "@testing-library/react";
+/**
+ * Vitest setup.
+ *
+ * This file deliberately does NOT stub `File`, `Blob`, `fetch` or
+ * `AbortController`. It used to, and the stubs were wrong in ways that let
+ * real bugs pass: `MockFile.size` summed `parts.length`, so it reported
+ * character counts instead of byte lengths and `NaN` for `Blob` parts —
+ * and `NaN > limit` is `false`, so an oversized file silently passed
+ * validation. `MockAbortController.abort()` never fired its listeners, so
+ * cancellation could not be tested at all.
+ *
+ * Node 18 is the oldest version CI runs, and it provides native `Blob`,
+ * `fetch`, `AbortController` and `crypto`. The single gap is `File`, which
+ * only became a global in Node 20 — so it is filled from `node:buffer`,
+ * which is the same spec implementation, not a hand-written imitation.
+ *
+ * Tests that need a fake `fetch` should stub it themselves, so the fake is
+ * visible in the test that depends on it.
+ */
+import { File as NodeFile } from "node:buffer";
 import { webcrypto } from "node:crypto";
 import { afterEach, vi } from "vitest";
 
-// Polyfill crypto for Node.js 18 compatibility
-if (typeof globalThis.crypto === "undefined") {
-  globalThis.crypto = webcrypto as any;
-}
-if (typeof global.crypto === "undefined") {
-  global.crypto = webcrypto as any;
-}
-
-// Mock fetch globally - ensure compatibility with Node.js 18
-if (typeof globalThis.fetch === "undefined") {
-  globalThis.fetch = vi.fn();
-}
-global.fetch = vi.fn();
-
-// Mock AbortController
-class MockAbortController {
-  signal: AbortSignal;
-  constructor() {
-    this.signal = {
-      aborted: false,
-      onabort: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    } as unknown as AbortSignal;
-  }
-  abort() {
-    (this.signal as any).aborted = true;
-  }
-}
-
-// Ensure AbortController is available globally for Node.js 18 compatibility
-if (typeof globalThis.AbortController === "undefined") {
-  globalThis.AbortController = MockAbortController as any;
-}
-global.AbortController = MockAbortController as any;
-
-// Mock File API - ensure compatibility with Node.js 18
-class MockFile {
-  name: string;
-  size: number;
-  type: string;
-  lastModified: number;
-
-  constructor(parts: any[], filename: string, options: any = {}) {
-    this.name = filename;
-    this.size = parts.reduce((acc, curr) => acc + curr.length, 0);
-    this.type = options.type || "";
-    this.lastModified = options.lastModified || Date.now();
-  }
-
-  slice(start?: number, end?: number) {
-    return new Blob(["mock data"]);
-  }
-}
-
-// Ensure File is available globally for Node.js 18 compatibility
+// Node 18 exposes File from node:buffer but not on globalThis (added in Node 20).
 if (typeof globalThis.File === "undefined") {
-  globalThis.File = MockFile as any;
-}
-global.File = MockFile as any;
-
-// Mock Blob
-class MockBlob {
-  size: number;
-  type: string;
-
-  constructor(parts: any[], options: any = {}) {
-    this.size = parts.reduce((acc, curr) => acc + curr.length, 0);
-    this.type = options.type || "";
-  }
+  globalThis.File = NodeFile as unknown as typeof globalThis.File;
 }
 
-global.Blob = MockBlob as any;
+// Node 16 lacks the Web Crypto global. Node 18+ provides it natively.
+if (typeof globalThis.crypto === "undefined") {
+  globalThis.crypto = webcrypto as unknown as Crypto;
+}
 
-// Clean up
 afterEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });


### PR DESCRIPTION
Closes #209.

`setupTests.ts` guarded each polyfill with `if (typeof X === "undefined")` and then assigned unconditionally on the very next line:

```ts
if (typeof globalThis.File === "undefined") {
  globalThis.File = MockFile as any;
}
global.File = MockFile as any;   // <- always runs
```

Same pattern for `Blob`, `fetch` and `AbortController`. So every test ran against hand-written stubs even on Node versions where all four are native.

## The stubs hid real failures

`MockFile.size` summed `parts.length`:

| input | mock | real |
|---|---|---|
| `"héllo"` | 5 | **6** (é is two bytes) |
| `"👋"` | 2 | **4** |
| `new Blob(["12345"])` | **NaN** | 5 |
| `new ArrayBuffer(1024)` | **NaN** | 1024 |

`NaN > limit` is `false`, so an oversized file passed a `maxFileSize` check.

`MockAbortController.abort()` set `signal.aborted` but `addEventListener` was a `vi.fn()`, so no handler ever ran — cancellation was untestable. `global.fetch = vi.fn()` resolved to `undefined` for every test.

`chain-validation.test.ts` shows the cost. Its `makeFile` helper built files from `new ArrayBuffer(sizeBytes)` — scored as `NaN` by the mock — and the author worked around it:

```ts
// File constructor may not respect exact size, so override
Object.defineProperty(f, "size", { value: sizeBytes });
```

The real constructor reports byte length correctly, so that override is removed in this PR.

## What replaces them

Node 18 is the oldest version CI runs, and it provides native `Blob`, `fetch`, `AbortController` and `crypto`. The one genuine gap is `File`, which only became a global in Node 20 — verified locally rather than assumed:

```
node v18.18.2   globalThis.File undefined   node:buffer.File function
node v22.14.0   globalThis.File function    node:buffer.File function
```

So `File` is filled from `node:buffer` when missing. That is the same spec implementation, not an imitation, so byte semantics stay correct on every supported version. Tests needing a fake `fetch` now stub it themselves with `vi.stubGlobal`, which `afterEach` unstubs — the fake is visible in the test that depends on it.

## Verification

New `src/__tests__/test-harness.test.ts` pins the behaviour the stubs got wrong, so this cannot silently regress. I confirmed it fails for the right reason by running it against the previous `setupTests.ts`:

```
against old stubbed harness:  9 failed (9)
against this harness:         9 passed (9)
```

Full suite on every Node version in the CI matrix:

```
node v18.18.2  ->  181 passed
node v22.14.0  ->  181 passed
node v25.8.0   ->  181 passed
```

`tsc` clean, `eslint` 0 errors, coverage baseline unchanged at 33.11%.

## Note

This unblocks #210 and the pending security investigation. Any test written for `maxFileSize` enforcement or upload cancellation was previously asserting against stub behaviour; those are now trustworthy.
