### PR TITLE
fix: emit CommonJS as .cjs so require() works

### DIFF
--- a/packages/pushduck/package.json
+++ b/packages/pushduck/package.json
@@ -17,54 +17,111 @@
     "type": "github",
     "url": "https://github.com/sponsors/abhay-ramesh"
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./server": {
-      "types": "./dist/server.d.ts",
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.js"
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
     },
     "./client": {
-      "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.js"
+      "import": {
+        "types": "./dist/client.d.mts",
+        "default": "./dist/client.mjs"
+      },
+      "require": {
+        "types": "./dist/client.d.cts",
+        "default": "./dist/client.cjs"
+      }
     },
     "./react-native": {
-      "types": "./dist/react-native.d.ts",
-      "import": "./dist/react-native.mjs",
-      "require": "./dist/react-native.js"
+      "import": {
+        "types": "./dist/react-native.d.mts",
+        "default": "./dist/react-native.mjs"
+      },
+      "require": {
+        "types": "./dist/react-native.d.cts",
+        "default": "./dist/react-native.cjs"
+      }
     },
     "./adapters": {
-      "types": "./dist/adapters/index.d.ts",
-      "import": "./dist/adapters/index.mjs",
-      "require": "./dist/adapters/index.js"
+      "import": {
+        "types": "./dist/adapters/index.d.mts",
+        "default": "./dist/adapters/index.mjs"
+      },
+      "require": {
+        "types": "./dist/adapters/index.d.cts",
+        "default": "./dist/adapters/index.cjs"
+      }
     },
     "./adapters/nextjs": {
-      "types": "./dist/adapters/nextjs.d.ts",
-      "import": "./dist/adapters/nextjs.mjs",
-      "require": "./dist/adapters/nextjs.js"
+      "import": {
+        "types": "./dist/adapters/nextjs.d.mts",
+        "default": "./dist/adapters/nextjs.mjs"
+      },
+      "require": {
+        "types": "./dist/adapters/nextjs.d.cts",
+        "default": "./dist/adapters/nextjs.cjs"
+      }
     },
     "./adapters/nextjs-pages": {
-      "types": "./dist/adapters/nextjs-pages.d.ts",
-      "import": "./dist/adapters/nextjs-pages.mjs",
-      "require": "./dist/adapters/nextjs-pages.js"
+      "import": {
+        "types": "./dist/adapters/nextjs-pages.d.mts",
+        "default": "./dist/adapters/nextjs-pages.mjs"
+      },
+      "require": {
+        "types": "./dist/adapters/nextjs-pages.d.cts",
+        "default": "./dist/adapters/nextjs-pages.cjs"
+      }
     },
     "./adapters/express": {
-      "types": "./dist/adapters/express.d.ts",
-      "import": "./dist/adapters/express.mjs",
-      "require": "./dist/adapters/express.js"
+      "import": {
+        "types": "./dist/adapters/express.d.mts",
+        "default": "./dist/adapters/express.mjs"
+      },
+      "require": {
+        "types": "./dist/adapters/express.d.cts",
+        "default": "./dist/adapters/express.cjs"
+      }
     },
     "./adapters/fastify": {
-      "types": "./dist/adapters/fastify.d.ts",
-      "import": "./dist/adapters/fastify.mjs",
-      "require": "./dist/adapters/fastify.js"
+      "import": {
+        "types": "./dist/adapters/fastify.d.mts",
+        "default": "./dist/adapters/fastify.mjs"
+      },
+      "require": {
+        "types": "./dist/adapters/fastify.d.cts",
+        "default": "./dist/adapters/fastify.cjs"
+      }
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": ["./dist/server.d.cts"],
+      "client": ["./dist/client.d.cts"],
+      "react-native": ["./dist/react-native.d.cts"],
+      "adapters": ["./dist/adapters/index.d.cts"],
+      "adapters/nextjs": ["./dist/adapters/nextjs.d.cts"],
+      "adapters/nextjs-pages": ["./dist/adapters/nextjs-pages.d.cts"],
+      "adapters/express": ["./dist/adapters/express.d.cts"],
+      "adapters/fastify": ["./dist/adapters/fastify.d.cts"]
     }
   },
   "files": [
@@ -77,7 +134,7 @@
     "build": "tsdown",
     "build:analyze": "pnpm build && pnpm bundle:analyze",
     "bundle:analyze": "pnpm size-check && echo '\nFile Details:' && ls -la dist/",
-    "bundle:visualize": "npx esbuild-visualizer dist/index.js --open",
+    "bundle:visualize": "npx esbuild-visualizer dist/index.mjs --open",
     "size-check": "node scripts/size-check.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/pushduck/scripts/health-check.sh
+++ b/packages/pushduck/scripts/health-check.sh
@@ -126,7 +126,7 @@ echo "---------------------------------"
 
 if command -v gzip-size-cli &> /dev/null; then
     echo "Bundle sizes (gzipped):"
-    gzip-size-cli dist/*.js dist/*.mjs 2>/dev/null || print_warning "Could not analyze some bundles"
+    gzip-size-cli dist/*.cjs dist/*.mjs 2>/dev/null || print_warning "Could not analyze some bundles"
 else
     print_warning "gzip-size-cli not found, install with: npm i -g gzip-size-cli"
 fi
@@ -136,7 +136,7 @@ echo ""
 echo "📁 Verifying package files..."
 echo "-----------------------------"
 
-required_files=("dist/index.js" "dist/index.mjs" "dist/index.d.ts" "dist/client.js" "dist/server.js")
+required_files=("dist/index.cjs" "dist/index.mjs" "dist/index.d.cts" "dist/index.d.mts" "dist/client.cjs" "dist/client.mjs" "dist/server.cjs" "dist/server.mjs")
 
 for file in "${required_files[@]}"; do
     if [ -f "$file" ]; then

--- a/packages/pushduck/tsdown.config.ts
+++ b/packages/pushduck/tsdown.config.ts
@@ -24,9 +24,12 @@ export default defineConfig({
   treeshake: true,
   sourcemap: false,
   external: ["react", "next", "crypto"],
-  // Use outExtensions instead of outExtension for tsdown
+  // The package is "type": "module", so a .js file is parsed as ESM by Node.
+  // Emitting the CommonJS build as .js therefore produced files Node could not
+  // load via require() at all. CJS must carry the .cjs extension.
   outExtensions: ({ format }) => ({
-    js: format === "cjs" ? ".js" : ".mjs",
+    js: format === "cjs" ? ".cjs" : ".mjs",
+    dts: format === "cjs" ? ".d.cts" : ".d.mts",
   }),
   platform: "neutral",
   target: "es2020",


### PR DESCRIPTION
Closes #207.

The package is `"type": "module"`, so Node parses every `.js` file as ESM. tsdown was emitting the **CommonJS** build to `.js`, which meant that output could not be loaded by `require()` at all.

Reproduced on the published `0.6.0` and on a fresh build of `main`, with `react` installed so this is not a missing-peer artifact:

```
require(pushduck)         FAIL: Cannot find module './use-upload-route-....js'
require(pushduck/server)  FAIL: Cannot find module './client-....js'
import(pushduck/server)   OK
```

ESM consumers were unaffected, which is why this went unreported for so long — the primary audience is Next.js App Router. But every `require()` consumer (CJS Express/Fastify apps, `next.config.js`, Jest without an ESM transform, anything with `"type": "commonjs"`) simply could not load the package, while the `exports` map advertised a `require` condition for all of them.

## Changes

- **tsdown** emits `.cjs`/`.d.cts` for CommonJS and `.mjs`/`.d.mts` for ESM.
- **`exports` uses per-condition types**, so the `require` branch resolves `.d.cts` and `import` resolves `.d.mts`. publint previously warned the single shared `"types"` was interpreted as ESM under `require`.
- `main`/`types` point at the CJS build; `module` stays on ESM.
- **`typesVersions`** added so legacy `node10` TypeScript resolution finds subpath types — that was already broken before this change.
- **`health-check.sh`** required `dist/index.js`, `dist/index.d.ts`, `dist/client.js`, `dist/server.js` and `exit 1`s when they are missing. **It runs in the publish workflow**, so without this fix the next release would have failed. Its gzip-size glob moved from `dist/*.js` to `dist/*.cjs`.
- `bundle:visualize` pointed at the now-nonexistent `dist/index.js`.

## Verification

From a packed tarball — all entry points, both module systems:

```
require:  pushduck, /server, /client, /adapters, /adapters/express   OK
import :  pushduck, /server, /client, /adapters, /adapters/express   OK
```

`publint`: **All good.**

`attw --pack`: **No problems found** — `node10`, `node16 (CJS)`, `node16 (ESM)` and `bundler` all green across 9 entry points. Previously every entry was `ESM (dynamic import only)` from CJS, with 4 subpaths failing outright.

Types checked against a real consumer project on TypeScript 7:

| config | result |
|---|---|
| `module: Node16` / `moduleResolution: Node16` | clean |
| `module: ESNext` / `moduleResolution: Bundler` | clean |
| CJS consumer (`.cts`, Node16) | clean |

`tsc` clean, 181 tests pass, size-check within limits, and `health-check.sh` reports *"Package is healthy and ready for release"*.

## Note for the release

This changes published file names (`dist/index.js` → `dist/index.cjs`). Anyone deep-importing `pushduck/dist/*` paths directly — never a supported entry point — would be affected. Everything going through the `exports` map is unaffected, and CJS consumers go from broken to working.
