### PR TITLE
fix(storage): sign presigned download URLs against the S3 API endpoint

### DIFF
--- a/packages/pushduck/src/__tests__/presigned-download-url.test.ts
+++ b/packages/pushduck/src/__tests__/presigned-download-url.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for #168 — presigned download URLs.
+ *
+ * Uses real aws4fetch signing (no mock) so the assertions are about the
+ * actual SigV4 canonical request, not a stub's idea of one. The clock is
+ * frozen because X-Amz-Date has second granularity and one test compares
+ * two signatures produced by separate calls.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createUploadConfig } from "../core/config/upload-config";
+import { createS3RouterWithConfig } from "../core/router/router-v2";
+import {
+  generatePresignedDownloadUrl,
+  resetS3Client,
+} from "../core/storage/client";
+
+const baseProvider = {
+  bucket: "test-bucket",
+  region: "us-east-1",
+  accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+};
+
+describe("presigned download URLs (#168)", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+  beforeEach(() => {
+    resetS3Client();
+  });
+
+  it("signs against the S3 API host, not a configured custom domain", async () => {
+    const { config } = createUploadConfig()
+      .provider("aws", { ...baseProvider, customDomain: "https://cdn.example.com" })
+      .build();
+
+    const url = new URL(await generatePresignedDownloadUrl(config, "uploads/a.jpg", 900));
+
+    // host is part of the SigV4 canonical request and cannot be swapped after
+    // signing, so the URL host must be the host the signature was computed for.
+    expect(url.host).toBe("test-bucket.s3.us-east-1.amazonaws.com");
+    expect(url.host).not.toBe("cdn.example.com");
+  });
+
+  it("produces a credential scope that names the s3 service", async () => {
+    const { config } = createUploadConfig()
+      .provider("aws", { ...baseProvider, customDomain: "https://cdn.example.com" })
+      .build();
+
+    const url = new URL(await generatePresignedDownloadUrl(config, "uploads/a.jpg", 900));
+    const credential = decodeURIComponent(url.searchParams.get("X-Amz-Credential")!);
+
+    // Signing against a CDN host left this as ".../us-east-1//aws4_request",
+    // because aws4fetch infers the service from the hostname.
+    expect(credential).toContain("/us-east-1/s3/aws4_request");
+    expect(credential).not.toContain("//aws4_request");
+  });
+
+  it("is unaffected by whether a custom domain is configured", async () => {
+    const { config: withDomain } = createUploadConfig()
+      .provider("aws", { ...baseProvider, customDomain: "https://cdn.example.com" })
+      .build();
+    const a = new URL(await generatePresignedDownloadUrl(withDomain, "uploads/a.jpg", 900));
+
+    resetS3Client();
+    const { config: plain } = createUploadConfig().provider("aws", baseProvider).build();
+    const b = new URL(await generatePresignedDownloadUrl(plain, "uploads/a.jpg", 900));
+
+    expect(a.searchParams.get("X-Amz-SignedHeaders")).toContain("host");
+    // Same key, credentials and expiry: the signature must not depend on a
+    // custom domain that plays no part in the request being signed.
+    expect(a.searchParams.get("X-Amz-Signature")).toBe(
+      b.searchParams.get("X-Amz-Signature")
+    );
+  });
+
+  it("presigns R2 against the R2 API host, never the custom domain", async () => {
+    const { config } = createUploadConfig()
+      .provider("cloudflareR2", {
+        ...baseProvider,
+        accountId: "abc123",
+        region: "auto",
+        customDomain: "https://files.example.com",
+      })
+      .build();
+
+    const url = new URL(await generatePresignedDownloadUrl(config, "uploads/a.jpg", 900));
+
+    // Cloudflare: "Presigned URLs work with the S3 API domain and cannot be
+    // used with custom domains."
+    expect(url.host).not.toBe("files.example.com");
+    expect(url.host).toContain("r2.cloudflarestorage.com");
+  });
+
+  it("still works when no custom domain is configured", async () => {
+    const { config } = createUploadConfig().provider("aws", baseProvider).build();
+
+    const url = new URL(await generatePresignedDownloadUrl(config, "uploads/a.jpg", 900));
+
+    expect(url.host).toBe("test-bucket.s3.us-east-1.amazonaws.com");
+    expect(url.searchParams.get("X-Amz-Signature")).toBeTruthy();
+  });
+
+  it("honours the route's .expiresIn() on the completion path", async () => {
+    const { s3, config } = createUploadConfig().provider("aws", baseProvider).build();
+
+    const router = createS3RouterWithConfig(
+      {
+        shortLived: s3
+          .image()
+          .maxFileSize("1MB")
+          .expiresIn(60)
+          .middleware(async () => ({})),
+      },
+      config
+    );
+
+    const [result] = await router.handleUploadComplete(
+      "shortLived",
+      new Request("http://localhost"),
+      [
+        {
+          key: "uploads/a.jpg",
+          file: { name: "a.jpg", size: 1024, type: "image/jpeg" },
+          metadata: {},
+        } as never,
+      ]
+    );
+
+    expect(result.success).toBe(true);
+    expect(new URL(result.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("60");
+  });
+
+  it("falls back to one hour when the route sets no expiry", async () => {
+    const { s3, config } = createUploadConfig().provider("aws", baseProvider).build();
+
+    const router = createS3RouterWithConfig(
+      { plain: s3.image().maxFileSize("1MB").middleware(async () => ({})) },
+      config
+    );
+
+    const [result] = await router.handleUploadComplete(
+      "plain",
+      new Request("http://localhost"),
+      [
+        {
+          key: "uploads/b.jpg",
+          file: { name: "b.jpg", size: 1024, type: "image/jpeg" },
+          metadata: {},
+        } as never,
+      ]
+    );
+
+    expect(new URL(result.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("3600");
+  });
+});

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -987,11 +987,13 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
         // Get file URL
         const url = getFileUrl(this.config, completion.key);
 
-        // Generate presigned download URL (expires in 1 hour by default)
+        // Generate presigned download URL. Honours the route's .expiresIn(),
+        // falling back to 1 hour, so a route that shortens its upload window
+        // does not hand back a long-lived download URL.
         const presignedUrl = await generatePresignedDownloadUrl(
           this.config,
           completion.key,
-          3600
+          routeConfig.expiresIn ?? 3600
         );
 
         // Call onUploadComplete hook

--- a/packages/pushduck/src/core/storage/client.ts
+++ b/packages/pushduck/src/core/storage/client.ts
@@ -615,7 +615,23 @@ export interface PresignedUrlResult {
 }
 
 /**
- * Generates a presigned URL for downloading/viewing a file from S3
+ * Generates a presigned URL for downloading/viewing a file from S3.
+ *
+ * The URL is always signed against the provider's S3 API endpoint, never a
+ * configured `customDomain` — the same rule `generatePresignedUploadUrl`
+ * follows, and for the same reason: a custom domain is a read-only CDN front
+ * that does not serve the S3 API. Cloudflare states this explicitly —
+ * "Presigned URLs work with the S3 API domain and cannot be used with custom
+ * domains" (https://developers.cloudflare.com/r2/api/s3/presigned-urls/).
+ *
+ * `host` is part of the SigV4 canonical request, so the host cannot be
+ * swapped after signing. Signing against the custom domain also left the
+ * credential scope without a service (`.../us-east-1//aws4_request`), because
+ * aws4fetch infers the service from the hostname and a CDN host is not
+ * inferable.
+ *
+ * If your bucket is public, prefer `getFileUrl()`, which returns the clean
+ * custom-domain URL and keeps CDN caching intact.
  */
 export async function generatePresignedDownloadUrl(
   uploadConfig: UploadConfig,
@@ -626,7 +642,7 @@ export async function generatePresignedDownloadUrl(
   const config = getS3CompatibleConfig(uploadConfig.provider);
 
   try {
-    const s3Url = buildPublicUrl(key, config);
+    const s3Url = buildS3Url(key, config);
     const url = new URL(s3Url);
 
     // Add expiration as query parameter


### PR DESCRIPTION
Fixes the two **pure bugs** in #168. The `visibility` option is deliberately not included — it is a feature and needs an API decision (see below).

Supersedes #182 by @3nvy, credited as co-author on the commit.

## 1. Download URLs were signed against the custom domain

`host` is part of the SigV4 canonical request, so when `customDomain` is configured the URL was signed for a CDN host that does not serve the S3 API. Cloudflare states this outright:

> Presigned URLs work with the S3 API domain and **cannot be used with custom domains**.

Your upload path already followed this rule — there is a comment in `client.ts` explaining that a custom domain is a read-only CDN front that does not accept S3 API operations. The download path was missed in that pass. This applies the same rule to it.

**Scope:** only configurations with `customDomain` set. Without one, `buildPublicUrl` and `buildS3Url` produce identical output, so users without a custom domain were never affected. Verified by mirroring both builders:

```
aws, no customDomain      same=true
aws + customDomain        same=false   signed against cdn.example.com
r2  + customDomain        same=false   signed against files.example.com
```

### The malformed credential scope was a symptom, not a second bug

I reported `.../us-east-1//aws4_request` on the issue as an independent defect. It is not — `aws4fetch` infers the service from the hostname, and a CDN host is not inferable. Correcting the URL restores it:

```
before:  host cdn.example.com                    cred .../us-east-1//aws4_request
after:   host bucket.s3.us-east-1.amazonaws.com  cred .../us-east-1/s3/aws4_request
```

One line fixes both. I have corrected the issue comment.

## 2. The completion path hardcoded a 3600s download expiry

`router-v2.ts` ignored the route's `.expiresIn()`, so a route that deliberately shortened its window still handed back a one-hour download URL. Now `routeConfig.expiresIn ?? 3600`.

## Tests

`presigned-download-url.test.ts` uses real `aws4fetch` signing with a frozen clock (`X-Amz-Date` has second granularity and one test compares two signatures).

I confirmed they fail for the right reason by running them against the unfixed code:

```
against unfixed:  5 failed | 2 passed
against fixed:    7 passed
```

The 2 that pass on unfixed code are exactly the ones asserting behaviour that **should not** change — no custom domain configured, and the 3600 default when a route sets no expiry. They are regression guards for the working path.

Full suite: **188 passed**. `tsc` clean, `eslint` 0 errors.

## What this does not prove

Without MinIO or a live bucket, these tests assert the correctness of the SigV4 canonical request, not a 200 from a real provider. The evidence is the canonical request plus vendor documentation. An integration test against MinIO in CI would close that gap and is worth doing separately.

## Deliberately out of scope

`visibility: 'public' | 'private'` (the remaining part of #168) is a feature, so it belongs in a minor release rather than this patch. There is also an API question to settle first: every provider already defaults `acl: "private"`, so an independent `visibility` gives two ways to express one intent and allows contradictory combinations like `acl: "public-read", visibility: "private"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Presigned download links now work reliably with AWS and compatible S3 storage providers.
  - Signed downloads use the correct storage API endpoint, even when custom domains are configured.
  - Upload completion now respects route-specific expiration settings, with a one-hour default when none is set.

- **Documentation**
  - Clarified endpoint requirements and signing behavior for download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->