### PR TITLE
refactor(storage): make signing the wrong host structurally impossible

### DIFF
--- a/packages/pushduck/src/__tests__/presigned-download-url.test.ts
+++ b/packages/pushduck/src/__tests__/presigned-download-url.test.ts
@@ -11,6 +11,7 @@ import { createUploadConfig } from "../core/config/upload-config";
 import { createS3RouterWithConfig } from "../core/router/router-v2";
 import {
   generatePresignedDownloadUrl,
+  generatePresignedUploadUrl,
   resetS3Client,
 } from "../core/storage/client";
 
@@ -156,5 +157,88 @@ describe("presigned download URLs (#168)", () => {
     );
 
     expect(new URL(result.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("3600");
+  });
+});
+
+/**
+ * The invariant behind #168, asserted across every provider rather than for
+ * one case: no presigned URL, upload or download, may ever be addressed to a
+ * custom domain. A custom domain is a read-only CDN front and does not serve
+ * the S3 API.
+ */
+describe("no signing path ever uses a custom domain", () => {
+  beforeEach(() => {
+    resetS3Client();
+  });
+
+  const CUSTOM_DOMAIN = "https://cdn.example.com";
+  const providers = [
+    {
+      name: "aws",
+      build: () =>
+        createUploadConfig()
+          .provider("aws", { ...baseProvider, customDomain: CUSTOM_DOMAIN })
+          .build(),
+    },
+    {
+      name: "cloudflareR2",
+      build: () =>
+        createUploadConfig()
+          .provider("cloudflareR2", {
+            ...baseProvider,
+            accountId: "abc123",
+            region: "auto",
+            customDomain: CUSTOM_DOMAIN,
+          })
+          .build(),
+    },
+    {
+      name: "digitalOceanSpaces",
+      build: () =>
+        createUploadConfig()
+          .provider("digitalOceanSpaces", {
+            ...baseProvider,
+            region: "nyc3",
+            customDomain: CUSTOM_DOMAIN,
+          })
+          .build(),
+    },
+    {
+      name: "minio",
+      build: () =>
+        createUploadConfig()
+          .provider("minio", {
+            ...baseProvider,
+            endpoint: "http://localhost:9000",
+            customDomain: CUSTOM_DOMAIN,
+          })
+          .build(),
+    },
+  ] as const;
+
+  for (const provider of providers) {
+    it(`${provider.name}: download URL is not on the custom domain`, async () => {
+      const { config } = provider.build();
+      const url = new URL(await generatePresignedDownloadUrl(config, "a.jpg", 900));
+      expect(url.host).not.toBe("cdn.example.com");
+      expect(url.searchParams.get("X-Amz-Signature")).toBeTruthy();
+    });
+
+    it(`${provider.name}: upload URL is not on the custom domain`, async () => {
+      const { config } = provider.build();
+      const result = await generatePresignedUploadUrl(config, { key: "a.jpg" });
+      expect(new URL(result.url).host).not.toBe("cdn.example.com");
+    });
+  }
+
+  it("getFileUrl is the accessor that does use the custom domain", async () => {
+    const { getFileUrl } = await import("../core/storage/client");
+    const { config } = createUploadConfig()
+      .provider("aws", { ...baseProvider, customDomain: CUSTOM_DOMAIN })
+      .build();
+
+    // The public/CDN URL is a separate, unsigned accessor — this is what a
+    // public bucket should hand to a browser.
+    expect(getFileUrl(config, "a.jpg")).toBe("https://cdn.example.com/a.jpg");
   });
 });

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -1064,8 +1064,25 @@ export interface UploadCompletion {
 export interface CompletionResponse {
   success: boolean;
   key: string;
+  /**
+   * The object's permanent public URL — your `customDomain` when one is
+   * configured, otherwise the provider URL.
+   *
+   * **Use this for public buckets.** It is unsigned, never expires and keeps
+   * CDN caching intact.
+   */
   url?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
+  /**
+   * A temporary signed URL for reading the object, for **private** buckets.
+   *
+   * Expires after the route's `.expiresIn()`, defaulting to one hour. Always
+   * addressed to the provider's S3 API endpoint, never to `customDomain` — a
+   * custom domain is a read-only CDN front and cannot serve a presigned
+   * request. Cloudflare documents this for R2 explicitly.
+   *
+   * If your bucket is public, prefer {@link CompletionResponse.url}.
+   */
+  presignedUrl?: string;
   file?: S3FileMetadata;
   error?: string;
 }

--- a/packages/pushduck/src/core/storage/client.ts
+++ b/packages/pushduck/src/core/storage/client.ts
@@ -470,13 +470,16 @@ export function resetS3Client(): void {
 // ========================================
 
 /**
- * Builds the S3 endpoint URL for a given key
+ * Builds the URL of the provider's S3 **API** endpoint for a key.
+ *
+ * Every request that talks to the storage provider — signed or not, GET,
+ * HEAD, PUT or DELETE — must be addressed here. This function never returns
+ * a `customDomain`: a custom domain is a read-only CDN front and does not
+ * serve the S3 API.
+ *
+ * Use {@link buildCdnUrl} for URLs handed to end users.
  */
-/**
- * Builds S3 URL for internal operations (HEAD, PUT, DELETE, etc.)
- * These operations need to communicate directly with S3, not through custom domain.
- */
-function buildS3Url(key: string, config: S3CompatibleConfig): string {
+function buildApiUrl(key: string, config: S3CompatibleConfig): string {
   if (config.endpoint) {
     // Custom endpoint (MinIO, R2, etc.)
     const baseUrl = config.endpoint.replace(/\/$/, "");
@@ -501,10 +504,56 @@ function buildS3Url(key: string, config: S3CompatibleConfig): string {
 }
 
 /**
- * Builds public URL for presigned URLs and public access.
- * Uses custom domain when configured, otherwise falls back to S3 URLs.
+ * Presigns a request against the provider's S3 API endpoint.
+ *
+ * This is the only way the codebase produces a presigned URL. Callers pass a
+ * key, never a URL, so there is no opportunity to sign the wrong host — the
+ * mistake that caused #168, where the download URL was built from the custom
+ * domain and every signature was rejected.
+ *
+ * @internal
  */
-function buildPublicUrl(key: string, config: S3CompatibleConfig): string {
+async function presignApiRequest(
+  uploadConfig: UploadConfig,
+  options: {
+    key: string;
+    method: "GET" | "PUT";
+    expiresIn: number;
+    headers?: Record<string, string>;
+  }
+): Promise<string> {
+  const awsClient = createS3Client(uploadConfig);
+  const config = getS3CompatibleConfig(uploadConfig.provider);
+
+  // Always the API endpoint. A custom domain cannot serve the S3 API, and
+  // `host` is part of the SigV4 canonical request so it cannot be swapped
+  // after signing.
+  const url = new URL(buildApiUrl(options.key, config));
+  url.searchParams.set("X-Amz-Expires", options.expiresIn.toString());
+
+  const signedRequest = await awsClient.sign(
+    new Request(url.toString(), {
+      method: options.method,
+      headers: options.headers,
+    }),
+    { aws: { signQuery: true } }
+  );
+
+  return signedRequest.url;
+}
+
+/**
+ * Builds the public, end-user-facing URL for a key — the custom domain / CDN
+ * URL when one is configured, otherwise the plain provider URL.
+ *
+ * This URL is **never** signed. It is what you hand to a browser for a
+ * publicly readable object. Signing anything built here produces a signature
+ * over a host that does not serve the S3 API, which the provider rejects;
+ * that was #168.
+ *
+ * Use {@link buildApiUrl} for anything that talks to the provider.
+ */
+function buildCdnUrl(key: string, config: S3CompatibleConfig): string {
   // If custom domain is configured, use it for public URLs
   if (config.customDomain) {
     const baseUrl = config.customDomain.replace(/\/$/, "");
@@ -638,34 +687,23 @@ export async function generatePresignedDownloadUrl(
   key: string,
   expiresIn: number = 3600
 ): Promise<string> {
-  const awsClient = createS3Client(uploadConfig);
   const config = getS3CompatibleConfig(uploadConfig.provider);
 
   try {
-    const s3Url = buildS3Url(key, config);
-    const url = new URL(s3Url);
-
-    // Add expiration as query parameter
-    url.searchParams.set("X-Amz-Expires", expiresIn.toString());
-
-    // Create a signed request for GET operation (download/view)
-    const signedRequest = await awsClient.sign(
-      new Request(url.toString(), {
-        method: "GET",
-      }),
-      {
-        aws: { signQuery: true },
-      }
-    );
+    const signedUrl = await presignApiRequest(uploadConfig, {
+      key,
+      method: "GET",
+      expiresIn,
+    });
 
     if (config.debug) {
       logger.presignedUrl(key, {
-        signedUrl: signedRequest.url,
+        signedUrl,
         expiresIn,
       });
     }
 
-    return signedRequest.url;
+    return signedUrl;
   } catch (error) {
     logger.error("Failed to generate presigned download URL", error, {
       operation: "generate-presigned-download-url",
@@ -810,44 +848,28 @@ export async function generatePresignedUploadUrl(
   uploadConfig: UploadConfig,
   options: PresignedUrlOptions
 ): Promise<PresignedUrlResult> {
-  const awsClient = createS3Client(uploadConfig);
   const config = getS3CompatibleConfig(uploadConfig.provider);
   const expiresIn = options.expiresIn ?? 3600; // 1 hour default
 
   try {
-    // Presigned UPLOAD (PUT) must use the S3 API endpoint (buildS3Url), not the custom domain.
-    // This applies to all S3-compatible providers: the "custom domain" is typically a read-only
-    // public/CDN URL (R2, CloudFront, Spaces CDN, etc.) and does not accept S3 API operations
-    // like PUT. Only the provider's native API host (e.g. r2.cloudflarestorage.com,
-    // s3.region.amazonaws.com, region.digitaloceanspaces.com) accepts signed PUT.
-    const s3Url = buildS3Url(options.key, config);
-    const url = new URL(s3Url);
-
-    // Add expiration as query parameter
-    url.searchParams.set("X-Amz-Expires", expiresIn.toString());
-
     // Split headers into signed (ACL only) and unsigned (Content-Type, metadata).
     // Only signed headers appear in X-Amz-SignedHeaders — unsigned headers are sent
     // by the client but not verified against the signature.
     const { signed, unsigned } = preparePresignHeaders(uploadConfig, options);
 
-    const signedRequest = await awsClient.sign(
-      new Request(url.toString(), {
-        method: "PUT",
-        headers: signed,
-      }),
-      {
-        aws: { signQuery: true },
-      },
-    );
+    const signedUrl = await presignApiRequest(uploadConfig, {
+      key: options.key,
+      method: "PUT",
+      expiresIn,
+      headers: signed,
+    });
 
     // Merge signed + unsigned so the client has a single flat map to apply.
     const requiredHeaders = { ...signed, ...unsigned };
 
     if (config.debug) {
       logger.presignedUrl(options.key, {
-        originalUrl: s3Url,
-        signedUrl: signedRequest.url,
+        signedUrl,
         signedHeaders: signed,
         unsignedHeaders: unsigned,
         config: {
@@ -860,7 +882,7 @@ export async function generatePresignedUploadUrl(
     }
 
     return {
-      url: signedRequest.url,
+      url: signedUrl,
       key: options.key,
       requiredHeaders: Object.keys(requiredHeaders).length > 0 ? requiredHeaders : undefined,
     };
@@ -928,7 +950,7 @@ export async function checkFileExists(
   const config = getS3CompatibleConfig(uploadConfig.provider);
 
   try {
-    const s3Url = buildS3Url(key, config);
+    const s3Url = buildApiUrl(key, config);
     const response = await awsClient.fetch(s3Url, {
       method: "HEAD",
     });
@@ -947,7 +969,7 @@ export async function checkFileExists(
  */
 export function getFileUrl(uploadConfig: UploadConfig, key: string): string {
   const config = getS3CompatibleConfig(uploadConfig.provider);
-  return buildPublicUrl(key, config);
+  return buildCdnUrl(key, config);
 }
 
 // ========================================
@@ -1053,7 +1075,7 @@ export async function uploadFileToS3(
   const config = getS3CompatibleConfig(uploadConfig.provider);
 
   try {
-    const s3Url = buildS3Url(key, config);
+    const s3Url = buildApiUrl(key, config);
 
     // Prepare headers
     const headers = prepareS3UploadHeaders(uploadConfig, options);
@@ -1475,7 +1497,7 @@ export async function getFileInfo(
   const config = getS3CompatibleConfig(uploadConfig.provider);
 
   try {
-    const s3Url = buildS3Url(key, config);
+    const s3Url = buildApiUrl(key, config);
     const response = await awsClient.fetch(s3Url, {
       method: "HEAD",
     });
@@ -1616,7 +1638,7 @@ export async function setFileMetadata(
 
     // Copy the file to itself with new metadata
     const sourceUrl = `${config.bucket}/${key}`;
-    const s3Url = buildS3Url(key, config);
+    const s3Url = buildApiUrl(key, config);
 
     const headers: Record<string, string> = {
       "x-amz-copy-source": sourceUrl,
@@ -1900,7 +1922,7 @@ export async function deleteFile(
 
   try {
     const s3Config = getS3CompatibleConfig(config);
-    const url = buildS3Url(key, s3Config);
+    const url = buildApiUrl(key, s3Config);
 
     const response = await awsClient.fetch(url, {
       method: "DELETE",


### PR DESCRIPTION
Follow-up to #215. No behaviour change — this makes the class of bug behind #168 unreachable rather than merely fixed.

## Why

#215 fixed the symptom by changing one call from `buildPublicUrl` to `buildS3Url`. Nothing stopped the next person making the same mistake: two similarly-named builders were in scope at every signing site, and the rule explaining which to use lived in a comment three functions away.

That is precisely how the bug happened. The **upload** path was corrected in an earlier pass with a comment explaining the rule; the **download** path was missed, because prose doesn't propagate.

## Naming — the trap was "public"

```
buildS3Url      ->  buildApiUrl    the provider's S3 API endpoint; every request
                                   that talks to the provider is addressed here
buildPublicUrl  ->  buildCdnUrl    the end-user-facing URL; never signed
```

A presigned download URL is *also* handed to the public, so `buildPublicUrl` read like a perfectly reasonable choice at a signing site. Nobody signs something called a CDN URL.

## A single signing seam

New internal `presignApiRequest()` is now the only place the codebase calls `awsClient.sign()`. Callers pass a **key and a method, never a URL** — so there is no longer any way to express "sign this custom domain".

```
awsClient.sign() call sites:   2 -> 1
buildCdnUrl callers:           getFileUrl only
```

Both presigners route through it, which also collapses the duplicated expiry / sign / URL-assembly logic they each carried.

## Public vs private access — no `visibility` option

This is the remaining piece of #168, and I'd argue against adding the option. It would give **two ways to express one intent** and permit contradictory configs like `acl: "public-read"` with `visibility: "private"`, which has no coherent meaning — and an implementer (or a code-generating agent) has to guess which wins.

The rule the AWS SDK already established is the guessable one: **a presign function always signs; the public URL is a different function.** That API already exists here:

| bucket | use | why |
|---|---|---|
| public | `result.url` / `getFileUrl()` | unsigned, permanent, CDN-cacheable |
| private | `result.presignedUrl` | signed, expiring, S3 API host |

The completion response already carries both fields. They were just undocumented. Both now say which is which, on the type users actually read in their editor.

## Tests

Extends the #168 suite with the invariant asserted **across every provider** rather than for a single case: neither the upload nor the download presigner may return a custom-domain host, for `aws`, `cloudflareR2`, `digitalOceanSpaces` and `minio`. Plus a test pinning `getFileUrl` as the accessor that *does* return the custom domain, so the two roles stay distinguishable.

**197 tests pass**, `tsc` clean, `eslint` 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload and download links across supported storage providers.
  * Temporary signed URLs now consistently use provider storage endpoints, including when a custom domain is configured.
  * Public file URLs continue to use configured custom domains.
* **Documentation**
  * Clarified the distinction between permanent public URLs and temporary signed URLs, including expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->