### PR TITLE
feat(router): give upload and download URLs independent expiry

### DIFF
--- a/docs/content/docs/api/s3-router.mdx
+++ b/docs/content/docs/api/s3-router.mdx
@@ -224,10 +224,13 @@ React to upload events:
 
 ### Presigned URL Expiry
 
-Control how long the generated presigned upload URL remains valid. Defaults to `3600` seconds (1 hour).
+Uploads and downloads have **independent lifetimes**. An upload window is usually
+minutes; a download link is usually hours. Both default to `3600` seconds (1 hour).
+
+Passing a number sets the **upload** window only:
 
 ```typescript
-// Short-lived window — 5 minutes
+// Short-lived upload window — 5 minutes. The download URL stays at 1 hour.
 secureUpload: s3
   .file()
   .maxFileSize('10MB')
@@ -239,6 +242,27 @@ largeFileUpload: s3
   .maxFileSize('500MB')
   .expiresIn(7200) // [!code highlight]
 ```
+
+Pass an object to set either side explicitly:
+
+```typescript
+// Tight upload window, long-lived download link
+sharedAsset: s3
+  .file()
+  .expiresIn({ upload: 300, download: 86400 }) // [!code highlight]
+
+// Only lengthen the download link
+report: s3
+  .file()
+  .expiresIn({ download: 604800 }) // [!code highlight]
+```
+
+<Callout type="warn">
+  The `presignedUrl` returned on completion is meant for **immediate use**.
+  Persist the object `key`, not the URL — a stored URL expires while your record
+  still points at it. Mint a fresh one on demand with
+  `storage.download.presignedUrl(key, ttl)`.
+</Callout>
 
 | Value | Duration |
 |-------|----------|

--- a/packages/pushduck/src/__tests__/presigned-download-url.test.ts
+++ b/packages/pushduck/src/__tests__/presigned-download-url.test.ts
@@ -106,36 +106,6 @@ describe("presigned download URLs (#168)", () => {
     expect(url.searchParams.get("X-Amz-Signature")).toBeTruthy();
   });
 
-  it("honours the route's .expiresIn() on the completion path", async () => {
-    const { s3, config } = createUploadConfig().provider("aws", baseProvider).build();
-
-    const router = createS3RouterWithConfig(
-      {
-        shortLived: s3
-          .image()
-          .maxFileSize("1MB")
-          .expiresIn(60)
-          .middleware(async () => ({})),
-      },
-      config
-    );
-
-    const [result] = await router.handleUploadComplete(
-      "shortLived",
-      new Request("http://localhost"),
-      [
-        {
-          key: "uploads/a.jpg",
-          file: { name: "a.jpg", size: 1024, type: "image/jpeg" },
-          metadata: {},
-        } as never,
-      ]
-    );
-
-    expect(result.success).toBe(true);
-    expect(new URL(result.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("60");
-  });
-
   it("falls back to one hour when the route sets no expiry", async () => {
     const { s3, config } = createUploadConfig().provider("aws", baseProvider).build();
 
@@ -157,6 +127,105 @@ describe("presigned download URLs (#168)", () => {
     );
 
     expect(new URL(result.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("3600");
+  });
+});
+
+/**
+ * Upload and download lifetimes are independent. `.expiresIn(number)` sets the
+ * upload window only — the meaning its JSDoc has always documented — and the
+ * object form addresses either side explicitly.
+ */
+describe("expiresIn: upload and download lifetimes", () => {
+  beforeEach(() => {
+    resetS3Client();
+  });
+
+  const completionFor = async (route: unknown, name: string) => {
+    const { config } = createUploadConfig().provider("aws", baseProvider).build();
+    const router = createS3RouterWithConfig({ [name]: route } as never, config);
+    const [result] = await router.handleUploadComplete(
+      name as never,
+      new Request("http://localhost"),
+      [
+        {
+          key: "uploads/a.jpg",
+          file: { name: "a.jpg", size: 1024, type: "image/jpeg" },
+          metadata: {},
+        } as never,
+      ]
+    );
+    return result;
+  };
+
+  const presignFor = async (route: unknown, name: string) => {
+    const { config } = createUploadConfig().provider("aws", baseProvider).build();
+    const router = createS3RouterWithConfig({ [name]: route } as never, config);
+    const [result] = await router.generatePresignedUrls(
+      name as never,
+      new Request("http://localhost"),
+      [{ name: "a.jpg", size: 1024, type: "image/jpeg" }]
+    );
+    return result;
+  };
+
+  const s3For = () => createUploadConfig().provider("aws", baseProvider).build().s3;
+
+  it("a number sets the upload window and leaves download at the default", async () => {
+    const s3 = s3For();
+    const route = s3.image().maxFileSize("1MB").expiresIn(60).middleware(async () => ({}));
+
+    const upload = await presignFor(route, "numberForm");
+    expect(new URL(upload.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("60");
+
+    // The behaviour CodeRabbit flagged on #182: a tight upload window must not
+    // silently shorten a download link that callers may hand to a browser.
+    const completion = await completionFor(route, "numberForm");
+    expect(new URL(completion.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("3600");
+  });
+
+  it("the object form sets both independently", async () => {
+    const s3 = s3For();
+    const route = s3
+      .image()
+      .maxFileSize("1MB")
+      .expiresIn({ upload: 60, download: 86400 })
+      .middleware(async () => ({}));
+
+    const upload = await presignFor(route, "bothForm");
+    expect(new URL(upload.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("60");
+
+    const completion = await completionFor(route, "bothForm");
+    expect(new URL(completion.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("86400");
+  });
+
+  it("download alone can be set without touching the upload window", async () => {
+    const s3 = s3For();
+    const route = s3
+      .image()
+      .maxFileSize("1MB")
+      .expiresIn({ download: 604800 })
+      .middleware(async () => ({}));
+
+    const upload = await presignFor(route, "downloadOnly");
+    expect(new URL(upload.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("3600");
+
+    const completion = await completionFor(route, "downloadOnly");
+    expect(new URL(completion.presignedUrl!).searchParams.get("X-Amz-Expires")).toBe("604800");
+  });
+
+  it("validates both forms against the 1..604800 range", () => {
+    const s3 = s3For();
+
+    expect(() => s3.image().expiresIn(0)).toThrow(/expiresIn must be between/);
+    expect(() => s3.image().expiresIn(604801)).toThrow(/expiresIn must be between/);
+    expect(() => s3.image().expiresIn({ upload: 0 })).toThrow(
+      /expiresIn.upload must be between/
+    );
+    expect(() => s3.image().expiresIn({ download: 604801 })).toThrow(
+      /expiresIn.download must be between/
+    );
+    // NaN previously slipped through: NaN <= 0 and NaN > 604800 are both false.
+    expect(() => s3.image().expiresIn(Number.NaN)).toThrow(/expiresIn must be between/);
   });
 });
 
@@ -227,7 +296,11 @@ describe("no signing path ever uses a custom domain", () => {
     it(`${provider.name}: upload URL is not on the custom domain`, async () => {
       const { config } = provider.build();
       const result = await generatePresignedUploadUrl(config, { key: "a.jpg" });
-      expect(new URL(result.url).host).not.toBe("cdn.example.com");
+      const url = new URL(result.url);
+      expect(url.host).not.toBe("cdn.example.com");
+      // Assert it is actually signed — an unsigned provider URL would
+      // otherwise satisfy the host check alone.
+      expect(url.searchParams.get("X-Amz-Signature")).toBeTruthy();
     });
   }
 

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -403,35 +403,73 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
   /**
    * Sets the expiration time for presigned upload URLs.
    *
-   * Controls how long the generated presigned URL remains valid for the client
-   * to perform the upload. Defaults to 3600 seconds (1 hour) if not set.
+   * Uploads and downloads have independent lifetimes. An upload window is
+   * usually minutes; a download link is usually hours. Passing a number sets
+   * the **upload** window only — the download URL returned on completion is
+   * unaffected and stays at its 1 hour default. Pass an object to set either
+   * or both.
    *
-   * @param seconds - Expiration time in seconds
+   * Both values must be between 1 and 604800 seconds (7 days).
+   *
+   * @param secondsOrConfig - Upload expiry in seconds, or `{ upload, download }`
    * @returns This route instance for chaining
    *
-   * @param seconds - Expiration in seconds. Must be between 1 and 604800 (7 days).
-   *
-   * @example Short-lived upload window
+   * @example Short-lived upload window (download stays at 1 hour)
    * ```typescript
    * const secureUpload = s3.file()
    *   .maxFileSize('10MB')
-   *   .expiresIn(300) // URL expires in 5 minutes
+   *   .expiresIn(300) // upload URL expires in 5 minutes
    * ```
    *
-   * @example Extended window for large files
+   * @example Independent upload and download lifetimes
    * ```typescript
-   * const largeFileUpload = s3.file()
-   *   .maxFileSize('500MB')
-   *   .expiresIn(7200) // URL expires in 2 hours
+   * const sharedAsset = s3.file()
+   *   .expiresIn({ upload: 300, download: 86400 })
    * ```
+   *
+   * @example Only lengthen the download link
+   * ```typescript
+   * const report = s3.file()
+   *   .expiresIn({ download: 604800 })
+   * ```
+   *
+   * @remarks
+   * The download URL on {@link CompletionResponse.presignedUrl} is meant for
+   * immediate use. Persist the object **key**, not the URL, and mint a fresh
+   * one with `storage.download.presignedUrl(key, ttl)` when you need it —
+   * otherwise a stored URL expires while the record still points at it.
    */
-  expiresIn(seconds: number): this {
-    if (seconds <= 0 || seconds > 604800) {
-      throw new Error(
-        `expiresIn must be between 1 and 604800 seconds (7 days), got ${seconds}`
-      );
+  expiresIn(seconds: number): this;
+  expiresIn(config: { upload?: number; download?: number }): this;
+  expiresIn(
+    secondsOrConfig: number | { upload?: number; download?: number }
+  ): this {
+    const assertRange = (label: string, value: number) => {
+      if (!Number.isFinite(value) || value <= 0 || value > 604800) {
+        throw new Error(
+          `${label} must be between 1 and 604800 seconds (7 days), got ${value}`
+        );
+      }
+    };
+
+    if (typeof secondsOrConfig === "number") {
+      assertRange("expiresIn", secondsOrConfig);
+      this.config.expiresIn = secondsOrConfig;
+      return this;
     }
-    this.config.expiresIn = seconds;
+
+    const { upload, download } = secondsOrConfig;
+
+    if (upload !== undefined) {
+      assertRange("expiresIn.upload", upload);
+      this.config.expiresIn = upload;
+    }
+
+    if (download !== undefined) {
+      assertRange("expiresIn.download", download);
+      this.config.downloadExpiresIn = download;
+    }
+
     return this;
   }
 
@@ -633,8 +671,17 @@ interface S3RouteConfig<TMetadata = any> {
   middleware?: S3Middleware<any, any>[];
   /** Path configuration for file organization */
   paths?: S3RoutePathConfig<TMetadata>;
-  /** Presigned upload URL expiration time in seconds (default: 3600 = 1 hour) */
+  /**
+   * Presigned **upload** URL expiry in seconds (default: 3600 = 1 hour).
+   * Set via `.expiresIn(seconds)` or `.expiresIn({ upload })`.
+   */
   expiresIn?: number;
+  /**
+   * Presigned **download** URL expiry in seconds for the URL returned on
+   * completion (default: 3600 = 1 hour). Set via `.expiresIn({ download })`.
+   * Independent of the upload window.
+   */
+  downloadExpiresIn?: number;
   /** Hook for upload start events */
   onUploadStart?: S3LifecycleHook<TMetadata>;
   /** Hook for upload progress events */
@@ -987,13 +1034,15 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
         // Get file URL
         const url = getFileUrl(this.config, completion.key);
 
-        // Generate presigned download URL. Honours the route's .expiresIn(),
-        // falling back to 1 hour, so a route that shortens its upload window
-        // does not hand back a long-lived download URL.
+        // Download expiry is independent of the upload window: an upload
+        // window is typically minutes, a download link hours. Reusing
+        // `expiresIn` here would silently shorten download URLs for any route
+        // that tightened its upload window, and `expiresIn` is documented as
+        // the upload expiry. Set this with `.expiresIn({ download })`.
         const presignedUrl = await generatePresignedDownloadUrl(
           this.config,
           completion.key,
-          routeConfig.expiresIn ?? 3600
+          routeConfig.downloadExpiresIn ?? 3600
         );
 
         // Call onUploadComplete hook
@@ -1075,10 +1124,15 @@ export interface CompletionResponse {
   /**
    * A temporary signed URL for reading the object, for **private** buckets.
    *
-   * Expires after the route's `.expiresIn()`, defaulting to one hour. Always
-   * addressed to the provider's S3 API endpoint, never to `customDomain` — a
-   * custom domain is a read-only CDN front and cannot serve a presigned
-   * request. Cloudflare documents this for R2 explicitly.
+   * Expires after the route's `.expiresIn({ download })`, defaulting to one
+   * hour. Independent of the upload window. Always addressed to the provider's
+   * S3 API endpoint, never to `customDomain` — a custom domain is a read-only
+   * CDN front and cannot serve a presigned request. Cloudflare documents this
+   * for R2 explicitly.
+   *
+   * Intended for immediate use. **Persist the `key`, not this URL** — a stored
+   * URL expires while the record still points at it. Mint a fresh one on
+   * demand with `storage.download.presignedUrl(key, ttl)`.
    *
    * If your bucket is public, prefer {@link CompletionResponse.url}.
    */

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -1019,30 +1019,44 @@ export class S3FileSchema extends S3Schema<File, File> {
   }
 
   /**
-   * Sets the expiration time for presigned upload URLs.
+   * Sets presigned URL expiry for this route.
    *
-   * Controls how long the generated presigned URL remains valid for the client
-   * to perform the upload. Defaults to 3600 seconds (1 hour) if not set.
+   * Uploads and downloads have independent lifetimes. An upload window is
+   * usually minutes; a download link is usually hours. Passing a number sets
+   * the **upload** window only — the download URL returned on completion is
+   * unaffected and stays at its 1 hour default. Pass an object to set either
+   * or both.
    *
-   * @param seconds - Expiration in seconds. Must be between 1 and 604800 (7 days).
-   * @returns S3Route instance with expiresIn set
+   * Both values must be between 1 and 604800 seconds (7 days).
    *
-   * @example Short-lived upload window
+   * @param secondsOrConfig - Upload expiry in seconds, or `{ upload, download }`
+   * @returns S3Route instance with the expiry set
+   *
+   * @example Short-lived upload window (download stays at 1 hour)
    * ```typescript
    * const secureUpload = s3.file()
    *   .maxFileSize('10MB')
-   *   .expiresIn(300) // URL expires in 5 minutes
+   *   .expiresIn(300) // upload URL expires in 5 minutes
    * ```
    *
-   * @example Extended window for large files
+   * @example Independent upload and download lifetimes
    * ```typescript
-   * const largeFileUpload = s3.file()
-   *   .maxFileSize('500MB')
-   *   .expiresIn(7200) // URL expires in 2 hours
+   * const sharedAsset = s3.file()
+   *   .expiresIn({ upload: 300, download: 86400 })
+   * ```
+   *
+   * @example Only lengthen the download link
+   * ```typescript
+   * const report = s3.file()
+   *   .expiresIn({ download: 604800 })
    * ```
    */
-  expiresIn(seconds: number) {
-    return new S3Route(this).expiresIn(seconds);
+  expiresIn(seconds: number): S3Route<any, any>;
+  expiresIn(config: { upload?: number; download?: number }): S3Route<any, any>;
+  expiresIn(secondsOrConfig: number | { upload?: number; download?: number }) {
+    // The overload signatures above are what callers see; this implementation
+    // just forwards to S3Route, which owns validation.
+    return new S3Route(this).expiresIn(secondsOrConfig as never);
   }
 
   // Helper methods


### PR DESCRIPTION
Implements the API discussed on #182 and resolves the review point CodeRabbit raised there. Co-authored with @3nvy.

## The problem

#215 made the completion-time download URL honour `routeConfig.expiresIn`. CodeRabbit flagged on #182 that this is a **contract change**:

> `routeConfig.expiresIn` is currently documented as the presigned **upload** URL expiry… this change also applies it to the completion-time download URL. That makes short upload windows also shorten returned download links.

That objection is correct and I merged past it. An upload window is typically **minutes**; a download link is typically **hours**. Coupling them forces a bad trade in one direction or the other — and `expiresIn` was documented as upload-only, so the coupling was silent.

## The API

`.expiresIn()` is now overloaded. **A number keeps its documented meaning** — the upload window — so existing routes are unaffected:

```ts
.expiresIn(300)                             // upload only; download stays 3600
.expiresIn({ upload: 300, download: 86400 }) // both, explicit
.expiresIn({ download: 604800 })             // download only
```

This differs from the sketch on #182 in one deliberate way: **there the number form set both.** I made it upload-only precisely so nothing changes for existing callers — the object form is how you opt into the second lifetime. That turns a silent behaviour change into an additive one.

Both forms validate against `1..604800`. The range check now also rejects `NaN`, which previously slipped through since `NaN <= 0` and `NaN > 604800` are both false.

## One implementation note worth reviewing

The overload is declared in **two** places because the chain crosses types: `S3FileSchema`/`S3ImageSchema.expiresIn()` forwards to `S3Route.expiresIn()`, which owns validation.

I only found this because the object form passed at runtime while `tsc` rejected it — the public chain starts on the schema, not the route. Verified from a consumer's perspective:

```
valid forms compile:        exit=0
typo'd key + string reject:  confirmed via @ts-expect-error
```

## Also in this PR

- **`CompletionResponse.presignedUrl` now documents the footgun** behind the original review comment: it is for immediate use, so persist the `key`, not the URL, and mint on demand with `storage.download.presignedUrl(key, ttl)`. A stored URL expires while your record still points at it.
- **Strengthened the upload-URL test CodeRabbit flagged on #216.** It asserted only the host, so an *unsigned* provider URL would have passed. Now asserts `X-Amz-Signature`, as the download test already did.
- Docs updated with both forms and the persistence warning.

## Tests

**200 pass.** New cases: number form leaves download at 3600, object form sets both independently, download-only leaves upload at 3600, and validation messages for each form.

## Note for #182

@3nvy — your fix landed in #215 and you are credited as co-author there and here. This PR is the object-form API you agreed to wait for, with the one correction above. #182 can close once this merges.
