### PR TITLE
docs: ship the recipes library, and stop promising one that didn't exist

### DIFF
--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -13,6 +13,7 @@
         "examples",
         "guides",
         "api",
+        "recipes",
         "--- Resources ---",
         "philosophy",
         "comparisons",

--- a/docs/content/docs/philosophy.mdx
+++ b/docs/content/docs/philosophy.mdx
@@ -207,7 +207,10 @@ npx @pushduck/cli add file-list
 - Creates unnecessary dependencies
 - Limits user choice
 
-**Our approach:** Document integration patterns
+**Our approach:** Document integration patterns — see [Recipes](/docs/recipes)
+for working code covering [image thumbnails](/docs/recipes/image-thumbnails),
+[video transcoding](/docs/recipes/video-transcoding) and
+[virus scanning](/docs/recipes/virus-scanning).
 
 <Callout type="warn">
   **⚠️ Bandwidth Note:** Server-side processing requires downloading from S3 (inbound) and uploading variants (outbound). This negates the "server never touches files" benefit.

--- a/docs/content/docs/recipes/database-record.mdx
+++ b/docs/content/docs/recipes/database-record.mdx
@@ -1,0 +1,109 @@
+---
+title: Database record
+description: Persist uploads correctly — store the key, never the presigned URL.
+icon: Database
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The most common thing to do after an upload is write a row about it. It is also
+the easiest place to make a mistake that only shows up an hour later.
+
+## Store the key, not the URL
+
+<Callout type="warn">
+  Never persist `presignedUrl`. It is a temporary signed URL — it expires, and
+  your row keeps pointing at a dead link. Store the `key`, which never changes,
+  and mint a URL when you need one.
+</Callout>
+
+```typescript
+const router = s3.createRouter({
+  documentUpload: s3
+    .file()
+    .maxFileSize("50MB")
+    .middleware(async ({ req }) => {
+      const user = await authenticate(req);
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ key, file, metadata }) => {
+      await db.uploads.create({
+        key, // the durable identifier
+        name: file.name,
+        size: file.size,
+        contentType: file.type,
+        ownerId: metadata.userId,
+      });
+    }),
+});
+```
+
+## Reading it back
+
+**Public bucket** — the URL is a pure function of the key, so nothing needs
+storing:
+
+```typescript
+const url = storage.download.url(row.key);
+```
+
+**Private bucket** — mint a short-lived URL at read time, with the TTL that
+moment actually needs:
+
+```typescript
+const url = await storage.download.presignedUrl(row.key, 300);
+```
+
+Minting is a local HMAC — no network call, microseconds. Doing it per request is
+cheaper than the bug you get from caching one.
+
+## Ownership belongs to middleware
+
+Note that `ownerId` comes from `metadata`, which came from `middleware`, which
+authenticated the request. It is **not** taken from the client.
+
+```typescript
+.middleware(async ({ req }) => {
+  const user = await authenticate(req);
+  return { userId: user.id }; // server-derived, trustworthy
+})
+```
+
+Anything the browser sends is a claim, not a fact. If a client-supplied field
+ends up in a `WHERE` clause, that is an access-control bug.
+
+## Recording intent before the upload
+
+`onUploadComplete` only fires if the client comes back to report completion. A
+browser that closes mid-upload leaves an object in your bucket with no row.
+
+If you need to reconcile, write a `pending` row when the URL is issued and
+promote it on completion:
+
+```typescript
+.middleware(async ({ req, file }) => {
+  const user = await authenticate(req);
+  const draft = await db.uploads.create({
+    name: file.name,
+    ownerId: user.id,
+    status: "pending",
+  });
+  return { userId: user.id, draftId: draft.id };
+})
+.onUploadComplete(async ({ key, metadata }) => {
+  await db.uploads.update({
+    id: metadata.draftId,
+    key,
+    status: "complete",
+  });
+})
+```
+
+Rows still `pending` after an hour are abandoned uploads — sweep them, and
+reconcile against a bucket listing if you need to catch orphaned objects too.
+
+## What this recipe doesn't cover
+
+Transactional guarantees between your bucket and your database (there are none —
+the sweep above is the pragmatic answer), deleting objects when rows are deleted,
+and soft-delete semantics.

--- a/docs/content/docs/recipes/database-record.mdx
+++ b/docs/content/docs/recipes/database-record.mdx
@@ -27,16 +27,28 @@ const router = s3.createRouter({
       return { userId: user.id };
     })
     .onUploadComplete(async ({ key, file, metadata }) => {
-      await db.uploads.create({
-        key, // the durable identifier
-        name: file.name,
-        size: file.size,
-        contentType: file.type,
-        ownerId: metadata.userId,
+      // Upsert, not create — see the idempotency note below.
+      await db.uploads.upsert({
+        where: { key },
+        create: {
+          key, // the durable identifier
+          name: file.name,
+          size: file.size,
+          contentType: file.type,
+          ownerId: metadata.userId,
+        },
+        update: {},
       });
     }),
 });
 ```
+
+<Callout type="warn">
+  Make this write **idempotent**. The client drives completion, so the request
+  can be retried — on a flaky network, or by anything that replays it. A plain
+  `create` then produces duplicate rows for one object. Upsert on `key`, or put
+  a unique constraint on `uploads.key` and handle the duplicate-key path.
+</Callout>
 
 ## Reading it back
 

--- a/docs/content/docs/recipes/image-thumbnails.mdx
+++ b/docs/content/docs/recipes/image-thumbnails.mdx
@@ -1,0 +1,119 @@
+---
+title: Image thumbnails
+description: Generate responsive derivatives with Sharp after upload.
+icon: Image
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Pushduck stores the original. Generating a thumbnail set is one hook away, using
+[Sharp](https://sharp.pixelplumbing.com/) — which is faster and better tested
+than anything a first-party feature would ship.
+
+## The route
+
+```typescript
+// app/api/upload/route.ts
+import { createUploadConfig } from "pushduck/server";
+
+const { s3 } = createUploadConfig()
+  .provider("aws", {
+    bucket: process.env.AWS_BUCKET_NAME!,
+    region: process.env.AWS_REGION!,
+  })
+  .build();
+
+const router = s3.createRouter({
+  imageUpload: s3
+    .image()
+    .maxFileSize("10MB")
+    .onUploadComplete(async ({ key }) => {
+      await queue.enqueue("thumbnail", { key, widths: [320, 768, 1600] });
+    }),
+});
+
+export const { GET, POST } = router.handlers;
+```
+
+<Callout type="warn">
+  Enqueue rather than resizing inline. Sharp on a 10MB source takes hundreds of
+  milliseconds to seconds, and `onUploadComplete` runs inside the client's
+  completion request.
+</Callout>
+
+## The worker
+
+```typescript
+// worker/thumbnail.ts
+import sharp from "sharp";
+
+export async function thumbnailJob({ key, widths }: { key: string; widths: number[] }) {
+  const source = await storage.download.presignedUrl(key, 3600);
+  const original = Buffer.from(await (await fetch(source)).arrayBuffer());
+
+  await Promise.all(
+    widths.map(async (width) => {
+      const resized = await sharp(original)
+        .resize({ width, withoutEnlargement: true })
+        .webp({ quality: 82 })
+        .toBuffer();
+
+      await storage.upload.file(resized, derivedKey(key, width));
+    })
+  );
+}
+
+const derivedKey = (key: string, width: number) =>
+  key.replace(/(\.[^.]+)?$/, `-${width}w.webp`);
+```
+
+## Deriving keys predictably
+
+If derivative keys are a pure function of the original key, you never need to
+store them — the client can construct the URL it wants.
+
+```typescript
+// shared between server and client
+export const thumbnailKey = (key: string, width: number) =>
+  key.replace(/(\.[^.]+)?$/, `-${width}w.webp`);
+```
+
+```tsx
+<img
+  src={publicUrl(thumbnailKey(file.key, 768))}
+  srcSet={[320, 768, 1600]
+    .map((w) => `${publicUrl(thumbnailKey(file.key, w))} ${w}w`)
+    .join(", ")}
+  sizes="(max-width: 768px) 100vw, 768px"
+/>
+```
+
+## Showing something immediately
+
+Thumbnails are seconds behind the upload. Rather than blocking on them, render
+the local file the browser already has:
+
+```tsx
+const preview = URL.createObjectURL(file);
+// ...and URL.revokeObjectURL(preview) when the component unmounts
+```
+
+That's instant, works before the upload finishes, and needs no signed URL — even
+for a private bucket.
+
+## Consider not doing this at all
+
+If your images are served through a CDN that resizes on the fly —
+[Cloudflare Images](https://developers.cloudflare.com/images/),
+[imgix](https://imgix.com), Vercel's image optimisation — you don't need a
+pipeline. You store one original and append query parameters. Fewer moving
+parts, no worker, no derivative storage to reconcile.
+
+Reach for this recipe when you need derivatives at rest: predictable keys,
+offline access, or a CDN that doesn't transform.
+
+## What this recipe doesn't cover
+
+EXIF/GPS stripping (`sharp().rotate().withMetadata({})` is a starting point),
+animated GIF and SVG handling, deleting derivatives when the original is
+deleted, and reprocessing when you change your width set.

--- a/docs/content/docs/recipes/image-thumbnails.mdx
+++ b/docs/content/docs/recipes/image-thumbnails.mdx
@@ -63,8 +63,14 @@ export async function thumbnailJob({ key, widths }: { key: string; widths: numbe
   );
 }
 
-const derivedKey = (key: string, width: number) =>
-  key.replace(/(\.[^.]+)?$/, `-${width}w.webp`);
+// Swap the extension for the derivative's, leaving directories alone.
+const derivedKey = (key: string, width: number) => {
+  const dot = key.lastIndexOf(".");
+  const slash = key.lastIndexOf("/");
+  // `dot > slash + 1` keeps dotfiles intact — ".env" has no extension to swap.
+  const base = dot > slash + 1 ? key.slice(0, dot) : key;
+  return `${base}-${width}w.webp`;
+};
 ```
 
 ## Deriving keys predictably
@@ -74,8 +80,12 @@ store them — the client can construct the URL it wants.
 
 ```typescript
 // shared between server and client
-export const thumbnailKey = (key: string, width: number) =>
-  key.replace(/(\.[^.]+)?$/, `-${width}w.webp`);
+export const thumbnailKey = (key: string, width: number) => {
+  const dot = key.lastIndexOf(".");
+  const slash = key.lastIndexOf("/");
+  const base = dot > slash + 1 ? key.slice(0, dot) : key;
+  return `${base}-${width}w.webp`;
+};
 ```
 
 ```tsx

--- a/docs/content/docs/recipes/image-thumbnails.mdx
+++ b/docs/content/docs/recipes/image-thumbnails.mdx
@@ -78,6 +78,14 @@ const derivedKey = (key: string, width: number) => {
 If derivative keys are a pure function of the original key, you never need to
 store them — the client can construct the URL it wants.
 
+<Callout type="warn">
+  This only works if the derivatives are **publicly readable**. On a private
+  bucket a constructed URL returns 403 — the client cannot sign it. Either write
+  derivatives to a public bucket or prefix, or mint the URL server-side with
+  `storage.download.presignedUrl(thumbnailKey(key, 768), 300)` after checking
+  the caller may read it.
+</Callout>
+
 ```typescript
 // shared between server and client
 export const thumbnailKey = (key: string, width: number) => {

--- a/docs/content/docs/recipes/index.mdx
+++ b/docs/content/docs/recipes/index.mdx
@@ -1,0 +1,91 @@
+---
+title: Recipes
+description: Copy-paste patterns for the things Pushduck deliberately doesn't do.
+icon: BookOpen
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Pushduck does uploads: presigning, validation, routing, lifecycle hooks. It does
+not process your files, scan them, bill for them, or store records about them —
+see [Philosophy](/docs/philosophy) for why.
+
+That scope only works if the boundary is a **doorway rather than a wall**. These
+recipes are the doorway. Each one is a small, standalone pattern that hangs off a
+hook Pushduck already gives you, using tools that do the job better than a
+first-party feature would.
+
+<Callout type="info">
+  Recipes are documentation, not a package. There is nothing to install and no
+  API to learn — copy the code, own it, change it. Nothing here is a Pushduck
+  feature, and none of it is on the roadmap to become one.
+</Callout>
+
+## The two hooks everything hangs off
+
+Almost every recipe is one of these two shapes.
+
+**`middleware`** runs *before* a presigned URL is issued. Use it to reject the
+request: authentication, quotas, per-user rules. Throwing here means no URL is
+issued and nothing is uploaded.
+
+```typescript
+s3.file().middleware(async ({ req, file }) => {
+  const user = await authenticate(req);
+  return { userId: user.id }; // becomes `metadata` downstream
+});
+```
+
+**`onUploadComplete`** runs *after* the object exists in your bucket. Use it to
+react: enqueue work, write a database row, scan, notify. `url` and `key` are
+always present here.
+
+```typescript
+s3.file().onUploadComplete(async ({ key, url, file, metadata }) => {
+  await queue.enqueue("process", { key });
+});
+```
+
+<Callout type="warn">
+  `onUploadComplete` runs inline with the client's completion request. Keep it
+  fast — **enqueue** work rather than doing it here. A recipe that transcodes a
+  video inside the hook will hold the request open for minutes and fail on any
+  serverless timeout.
+</Callout>
+
+## Available recipes
+
+| Recipe | Hook | What it shows |
+| --- | --- | --- |
+| [Image thumbnails](/docs/recipes/image-thumbnails) | `onUploadComplete` | Generating derivatives with Sharp |
+| [Video transcoding](/docs/recipes/video-transcoding) | client + `onUploadComplete` | Both handoff directions |
+| [Virus scanning](/docs/recipes/virus-scanning) | `onUploadComplete` | Quarantine and delete on failure |
+| [Database record](/docs/recipes/database-record) | `onUploadComplete` | Persisting the key, not the URL |
+| [Rate limiting](/docs/recipes/rate-limiting) | `middleware` | Rejecting before a URL is issued |
+
+## Contributing a recipe
+
+Recipes are the part of the project that scales with the community rather than
+with maintainer time, and contributions are genuinely welcome — a recipe you had
+to work out yourself is exactly the one somebody else is about to need.
+
+A good recipe:
+
+- **Solves one problem**, in one file, in under a page
+- **Uses a hook Pushduck already has** — no new library surface
+- **Names the tool it hands off to** and doesn't try to hide it
+- **Compiles.** Code that doesn't run is worse than no code
+- **Says what it doesn't handle.** Retries, idempotency and failure modes are
+  where real deployments differ; be explicit about what you left out
+
+Open a PR adding a file to `docs/content/docs/recipes/` and listing it in that
+directory's `meta.json`. If you are unsure whether an idea fits, open an issue
+first — "is this a recipe or a feature?" is a fair question and a fast one to
+answer.
+
+<Callout type="info">
+  A first-party extension mechanism is under consideration, which would let
+  some of these patterns install as packages rather than as copy-paste. Nothing
+  is committed yet, and recipes will keep working regardless — they are just
+  code you own.
+</Callout>

--- a/docs/content/docs/recipes/meta.json
+++ b/docs/content/docs/recipes/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Recipes",
+  "description": "Copy-paste patterns for the things Pushduck deliberately doesn't do",
+  "icon": "BookOpen",
+  "pages": [
+    "index",
+    "image-thumbnails",
+    "video-transcoding",
+    "virus-scanning",
+    "database-record",
+    "rate-limiting"
+  ]
+}

--- a/docs/content/docs/recipes/rate-limiting.mdx
+++ b/docs/content/docs/recipes/rate-limiting.mdx
@@ -13,6 +13,15 @@ your bucket** — your server is not in the path and cannot stop it.
 ## Daily quota
 
 ```typescript
+// Increment and set the TTL in one round trip. Doing them as two commands
+// risks a crash in between, which leaves a counter with no expiry — and a user
+// locked out permanently rather than until midnight.
+const INCR_WITH_TTL = `
+  local n = redis.call('INCR', KEYS[1])
+  if n == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end
+  return n
+`;
+
 const router = s3.createRouter({
   upload: s3
     .file()
@@ -21,8 +30,7 @@ const router = s3.createRouter({
       const user = await authenticate(req);
 
       const key = `uploads:${user.id}:${new Date().toISOString().slice(0, 10)}`;
-      const count = await redis.incr(key);
-      if (count === 1) await redis.expire(key, 86_400);
+      const count = await redis.eval(INCR_WITH_TTL, 1, key, "86400");
 
       const limit = user.plan === "pro" ? 1000 : 20;
       if (count > limit) {
@@ -35,6 +43,13 @@ const router = s3.createRouter({
 ```
 
 Throwing in middleware means no URL is issued and nothing reaches your bucket.
+
+<Callout type="warn">
+  Redis evaluates a Lua script atomically, so the counter can never outlive its
+  window. `INCR` followed by a separate `EXPIRE` is the common shorthand, but a
+  process dying between the two leaves a key with no TTL — and that user stays
+  blocked forever.
+</Callout>
 
 <Callout type="warn">
   Middleware runs **per file**, not per request. A client asking for ten
@@ -74,9 +89,8 @@ Daily quotas don't stop a burst. A short sliding window does, and composes with
 the quota above:
 
 ```typescript
-const burst = `burst:${user.id}`;
-const hits = await redis.incr(burst);
-if (hits === 1) await redis.expire(burst, 10);
+// Reuses INCR_WITH_TTL from above — same atomicity requirement applies.
+const hits = await redis.eval(INCR_WITH_TTL, 1, `burst:${user.id}`, "10");
 if (hits > 20) throw new Error("Slow down");
 ```
 

--- a/docs/content/docs/recipes/rate-limiting.mdx
+++ b/docs/content/docs/recipes/rate-limiting.mdx
@@ -1,0 +1,102 @@
+---
+title: Rate limiting
+description: Enforce per-user upload quotas before a presigned URL is issued.
+icon: Gauge
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Rate limiting belongs in `middleware`, because that is the only point where you
+can still say no. Once a presigned URL is issued, the upload goes **directly to
+your bucket** — your server is not in the path and cannot stop it.
+
+## Daily quota
+
+```typescript
+const router = s3.createRouter({
+  upload: s3
+    .file()
+    .maxFileSize("50MB")
+    .middleware(async ({ req }) => {
+      const user = await authenticate(req);
+
+      const key = `uploads:${user.id}:${new Date().toISOString().slice(0, 10)}`;
+      const count = await redis.incr(key);
+      if (count === 1) await redis.expire(key, 86_400);
+
+      const limit = user.plan === "pro" ? 1000 : 20;
+      if (count > limit) {
+        throw new Error(`Daily upload limit of ${limit} reached`);
+      }
+
+      return { userId: user.id };
+    }),
+});
+```
+
+Throwing in middleware means no URL is issued and nothing reaches your bucket.
+
+<Callout type="warn">
+  Middleware runs **per file**, not per request. A client asking for ten
+  presigned URLs runs this ten times — which is what you want for a file count
+  quota, and is worth knowing if you are counting requests instead.
+</Callout>
+
+## Quota by stored bytes
+
+Counting files is a poor proxy for cost. If you care about storage spend, count
+bytes — `file.size` is available in middleware.
+
+```typescript
+.middleware(async ({ req, file }) => {
+  const user = await authenticate(req);
+  const used = await db.usage.bytesFor(user.id);
+
+  if (used + file.size > user.quotaBytes) {
+    throw new Error("Storage quota exceeded");
+  }
+
+  return { userId: user.id };
+})
+```
+
+<Callout type="warn">
+  `file.size` is **declared by the client** and is not enforced by the presigned
+  PUT. A modified client can declare 1KB and upload 1GB. Treat this as a guard
+  against honest overuse, not against an attacker. Reconcile against actual
+  object sizes — a bucket listing, or S3 storage metrics — and enforce the hard
+  limit there.
+</Callout>
+
+## Short-window burst control
+
+Daily quotas don't stop a burst. A short sliding window does, and composes with
+the quota above:
+
+```typescript
+const burst = `burst:${user.id}`;
+const hits = await redis.incr(burst);
+if (hits === 1) await redis.expire(burst, 10);
+if (hits > 20) throw new Error("Slow down");
+```
+
+## Returning a useful error
+
+A thrown middleware error currently surfaces as a generic failure. Until
+error-to-status mapping lands, encode what the client needs in the message:
+
+```typescript
+throw new Error(
+  JSON.stringify({ code: "QUOTA_EXCEEDED", limit, resetsAt: endOfDay() })
+);
+```
+
+Not elegant, but it lets the client distinguish "you are out of quota until
+midnight" from "something broke", which is the difference between a useful UI
+and a shrug.
+
+## What this recipe doesn't cover
+
+Distributed correctness under concurrent requests (`INCR` is atomic; a
+read-then-write against Postgres is not), refunding quota when an upload is
+abandoned, and per-organisation rather than per-user accounting.

--- a/docs/content/docs/recipes/video-transcoding.mdx
+++ b/docs/content/docs/recipes/video-transcoding.mdx
@@ -1,0 +1,139 @@
+---
+title: Video transcoding
+description: Transcode before upload in the browser, or after upload on your server.
+icon: Video
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Pushduck does not transcode video, and won't — that means owning a job queue,
+worker infrastructure, progress reporting for a process that outlives the
+request, storage for intermediate artifacts, and codec licensing. That is a
+different product, and doing it badly is worse than not doing it.
+
+What Pushduck does is get the original into your bucket and tell you exactly
+when it landed. There are two places to hook transcoding onto that, and they
+have genuinely different trade-offs.
+
+## Option 1 — Transcode in the browser, before upload
+
+Best when you want to **shrink what crosses the network**: a 4K phone capture
+becomes 720p before a byte is uploaded. Costs you nothing in server compute.
+
+```typescript
+"use client";
+
+import { upload } from "@/lib/upload-client";
+
+async function handleFiles(files: File[]) {
+  // Your transcoder of choice — Mediabunny and ffmpeg.wasm both run in-browser.
+  const prepared = await Promise.all(files.map((file) => transcode(file)));
+  await upload.videoUpload().uploadFiles(prepared);
+}
+```
+
+**Trade-offs.** It's free for you and slow for the user — in-browser transcoding
+is CPU-bound and can take minutes on a laptop, longer on a phone, and may fail
+outright on low-memory devices. Feasible for short clips and modest resolutions;
+not for a 2GB source file.
+
+- [Mediabunny](https://github.com/Vanilagy/mediabunny) — modern, WebCodecs-based
+- [ffmpeg.wasm](https://ffmpegwasm.netlify.app/) — full FFmpeg, much larger bundle
+
+## Option 2 — Transcode after upload, on your server
+
+Best for **anything real**. The original lands in your bucket, and you enqueue
+the work.
+
+```typescript
+// app/api/upload/route.ts
+import { createUploadConfig } from "pushduck/server";
+
+const { s3 } = createUploadConfig()
+  .provider("aws", {
+    bucket: process.env.AWS_BUCKET_NAME!,
+    region: process.env.AWS_REGION!,
+  })
+  .build();
+
+const router = s3.createRouter({
+  videoUpload: s3
+    .file()
+    .accept(["video/*"])
+    .maxFileSize("500MB")
+    .middleware(async ({ req }) => {
+      const user = await authenticate(req);
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ key, metadata }) => {
+      // Hand off and return immediately. Do not transcode here.
+      await queue.enqueue("transcode", { key, userId: metadata.userId });
+    }),
+});
+
+export const { GET, POST } = router.handlers;
+```
+
+<Callout type="warn">
+  `onUploadComplete` runs inline with the client's completion request. Enqueue
+  the job and return. Transcoding inside the hook holds the request open for
+  minutes and will fail on any serverless timeout.
+</Callout>
+
+Your worker then does the actual work — reading the original from the bucket and
+writing derivatives back:
+
+```typescript
+// worker/transcode.ts — runs wherever your jobs run
+export async function transcodeJob({ key }: { key: string }) {
+  const source = await storage.download.presignedUrl(key, 3600);
+
+  // ffmpeg -i <source> -vf scale=-2:720 -c:v h264 out.mp4
+  const output = await runFfmpeg(source, { height: 720, codec: "h264" });
+
+  await storage.upload.file(output, key.replace(/\.[^.]+$/, "-720p.mp4"));
+  await db.videos.update({ key, status: "ready" });
+}
+```
+
+Note the worker mints its own download URL with the TTL *it* needs, rather than
+relying on the one returned at completion. That is the pattern to copy: persist
+the `key`, mint URLs on demand.
+
+## Option 3 — Hand off to a service
+
+If video is central to your product, a managed pipeline will beat anything you
+assemble. The hook is identical — you're enqueuing to someone else's queue.
+
+```typescript
+.onUploadComplete(async ({ key }) => {
+  await mux.video.assets.create({
+    inputs: [{ url: await storage.download.presignedUrl(key, 3600) }],
+    playback_policy: ["signed"],
+  });
+})
+```
+
+[Mux](https://mux.com), [Cloudflare Stream](https://developers.cloudflare.com/stream/)
+and [AWS MediaConvert](https://aws.amazon.com/mediaconvert/) all take a signed
+source URL and handle renditions, thumbnails and delivery.
+
+## Which to pick
+
+| | Browser | Your worker | Managed service |
+| --- | --- | --- | --- |
+| Server cost | none | yours | per-minute |
+| Upload size | reduced | full | full |
+| Large files | fails | fine | fine |
+| Setup | small | queue + worker | API key |
+
+Start with **Option 2** unless bandwidth is your bottleneck. Move to **Option 3**
+when renditions, captions or adaptive streaming enter the picture.
+
+## What this recipe doesn't cover
+
+Retries and idempotency (your queue should own both), telling the user when the
+job finishes (webhook or poll on your own status field), cleaning up originals
+after successful transcode, and failure handling when the source is corrupt or
+codec-unsupported. Those differ per deployment; wire them the way your
+infrastructure already does.

--- a/docs/content/docs/recipes/video-transcoding.mdx
+++ b/docs/content/docs/recipes/video-transcoding.mdx
@@ -85,20 +85,76 @@ writing derivatives back:
 
 ```typescript
 // worker/transcode.ts — runs wherever your jobs run
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 export async function transcodeJob({ key }: { key: string }) {
+  // ffmpeg reads the presigned URL directly over HTTP — no download step.
   const source = await storage.download.presignedUrl(key, 3600);
+  const output = await transcode(source, 720);
 
-  // ffmpeg -i <source> -vf scale=-2:720 -c:v h264 out.mp4
-  const output = await runFfmpeg(source, { height: 720, codec: "h264" });
-
-  await storage.upload.file(output, key.replace(/\.[^.]+$/, "-720p.mp4"));
+  await storage.upload.file(output, renditionKey(key, 720));
   await db.videos.update({ key, status: "ready" });
 }
+
+async function transcode(source: string, height: number): Promise<Buffer> {
+  const dir = await mkdtemp(join(tmpdir(), "transcode-"));
+  const out = join(dir, "out.mp4");
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const ff = spawn("ffmpeg", [
+        "-i", source,
+        "-vf", `scale=-2:${height}`, // -2 keeps the aspect ratio, even width
+        "-c:v", "libx264", "-crf", "23", "-preset", "veryfast",
+        "-c:a", "aac",
+        "-movflags", "+faststart", // moov atom first, so it streams
+        "-y", out,
+      ], { stdio: ["ignore", "ignore", "pipe"] });
+
+      let stderr = "";
+      ff.stderr.on("data", (d) => (stderr += d));
+      ff.on("error", reject); // ffmpeg not on PATH
+      ff.on("close", (code) =>
+        code === 0
+          ? resolve()
+          : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-500)}`))
+      );
+    });
+
+    return await readFile(out);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// Swap the extension, leaving directories and dotfiles alone.
+function renditionKey(key: string, height: number) {
+  const dot = key.lastIndexOf(".");
+  const slash = key.lastIndexOf("/");
+  const base = dot > slash + 1 ? key.slice(0, dot) : key;
+  return `${base}-${height}p.mp4`;
+}
 ```
+
+<Callout type="info">
+  `scale=-2:720` derives the width from the source aspect ratio and rounds to an
+  even number, which h264 requires — `-1` can produce an odd width and fail.
+  `+faststart` moves the moov atom to the front so the result can be played
+  before it fully downloads.
+</Callout>
 
 Note the worker mints its own download URL with the TTL *it* needs, rather than
 relying on the one returned at completion. That is the pattern to copy: persist
 the `key`, mint URLs on demand.
+
+<Callout type="warn">
+  Everything above assumes an `ffmpeg` binary on `PATH` in whatever runs your
+  jobs. That rules out most serverless runtimes — use a container, a VM, or
+  Option 3 below.
+</Callout>
 
 ## Option 3 — Hand off to a service
 

--- a/docs/content/docs/recipes/virus-scanning.mdx
+++ b/docs/content/docs/recipes/virus-scanning.mdx
@@ -61,6 +61,7 @@ database takes seconds.
 ```typescript
 // worker/scan.ts
 import NodeClam from "clamscan";
+import { Readable } from "node:stream";
 
 const clam = await new NodeClam().init({
   clamdscan: { host: process.env.CLAMD_HOST, port: 3310 },
@@ -68,9 +69,11 @@ const clam = await new NodeClam().init({
 
 export async function scanJob({ key }: { key: string }) {
   const url = await storage.download.presignedUrl(key, 600);
-  const body = await fetch(url);
+  const response = await fetch(url);
 
-  const { isInfected, viruses } = await clam.scanStream(body.body!);
+  // clamscan wants a Node stream; fetch gives a web ReadableStream.
+  const stream = Readable.fromWeb(response.body as never);
+  const { isInfected, viruses } = await clam.scanStream(stream);
 
   if (isInfected) {
     await storage.delete.file(key);
@@ -83,6 +86,12 @@ export async function scanJob({ key }: { key: string }) {
 ```
 
 Streaming the object into the scanner avoids buffering a 25MB file in memory.
+
+<Callout type="info">
+  `Readable.fromWeb` is the bridge between `fetch`'s web stream and the Node
+  stream `clamscan` expects. Passing `response.body` straight in fails at
+  runtime — the two stream types are not interchangeable.
+</Callout>
 
 ## Hosted alternatives
 

--- a/docs/content/docs/recipes/virus-scanning.mdx
+++ b/docs/content/docs/recipes/virus-scanning.mdx
@@ -52,6 +52,25 @@ const files = await db.attachments.findMany({
 });
 ```
 
+<Callout type="warn">
+  One filtered query is not enough. Any other route, admin view or background
+  job that lists objects can still serve a `pending-scan` file, and a public
+  bucket bypasses your database entirely. Keep the bucket **private**, and make
+  the status check a precondition of *minting a URL* rather than of one listing:
+
+  ```typescript
+  export async function downloadUrl(key: string, userId: string) {
+    const row = await db.attachments.findUnique({ where: { key } });
+    if (!row || row.ownerId !== userId) throw new Error("Not found");
+    if (row.status !== "clean") throw new Error("File is still being scanned");
+    return storage.download.presignedUrl(key, 300);
+  }
+  ```
+
+  With that as the only way to obtain a URL, "unscanned" and "unreachable" are
+  the same thing.
+</Callout>
+
 ## The scanner
 
 [ClamAV](https://www.clamav.net/) is the usual open-source choice, typically run

--- a/docs/content/docs/recipes/virus-scanning.mdx
+++ b/docs/content/docs/recipes/virus-scanning.mdx
@@ -1,0 +1,113 @@
+---
+title: Virus scanning
+description: Scan uploads after they land and quarantine anything infected.
+icon: ShieldAlert
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Presigned uploads go **straight from the browser to your bucket**. Your server
+never sees the bytes, so there is no point in the flow where it could scan them
+on the way past. Anything accepting user uploads has to scan after the fact.
+
+<Callout type="warn">
+  Treat an object as untrusted until it has been scanned. The window between
+  "uploaded" and "scanned" is real — do not serve the file, and do not hand its
+  key to another user, during that window.
+</Callout>
+
+## Quarantine by default
+
+The simplest correct design is a status field that starts out unsafe.
+
+```typescript
+// app/api/upload/route.ts
+const router = s3.createRouter({
+  attachmentUpload: s3
+    .file()
+    .maxFileSize("25MB")
+    .middleware(async ({ req }) => {
+      const user = await authenticate(req);
+      return { userId: user.id };
+    })
+    .onUploadComplete(async ({ key, file, metadata }) => {
+      await db.attachments.create({
+        key,
+        name: file.name,
+        ownerId: metadata.userId,
+        status: "pending-scan", // nothing serves this yet
+      });
+
+      await queue.enqueue("scan", { key });
+    }),
+});
+```
+
+Your read path filters on status, so an unscanned object is invisible by
+construction rather than by remembering to check.
+
+```typescript
+const files = await db.attachments.findMany({
+  where: { ownerId: userId, status: "clean" },
+});
+```
+
+## The scanner
+
+[ClamAV](https://www.clamav.net/) is the usual open-source choice, typically run
+as a long-lived service rather than spawned per file — loading its signature
+database takes seconds.
+
+```typescript
+// worker/scan.ts
+import NodeClam from "clamscan";
+
+const clam = await new NodeClam().init({
+  clamdscan: { host: process.env.CLAMD_HOST, port: 3310 },
+});
+
+export async function scanJob({ key }: { key: string }) {
+  const url = await storage.download.presignedUrl(key, 600);
+  const body = await fetch(url);
+
+  const { isInfected, viruses } = await clam.scanStream(body.body!);
+
+  if (isInfected) {
+    await storage.delete.file(key);
+    await db.attachments.update({ key, status: "infected", viruses });
+    return;
+  }
+
+  await db.attachments.update({ key, status: "clean" });
+}
+```
+
+Streaming the object into the scanner avoids buffering a 25MB file in memory.
+
+## Hosted alternatives
+
+Running ClamAV means running a service and keeping signatures current. Hosted
+options take a URL or bytes and hand back a verdict:
+
+- [VirusTotal](https://www.virustotal.com/) — many engines, rate-limited, public
+  submissions on the free tier
+- [Cloudmersive](https://cloudmersive.com/virus-api) — straightforward API
+- [AWS GuardDuty Malware Protection for S3](https://aws.amazon.com/guardduty/) —
+  scans on `PutObject` with no queue of your own; tags the object with the result
+
+The GuardDuty route is worth a look precisely because it needs no recipe: it
+hooks the bucket rather than your application.
+
+## Deleting versus keeping
+
+Deleting on detection is simplest and is what the code above does. If you need
+an audit trail, move the object to a quarantine bucket no application role can
+read, and record why. Do not leave an infected object in the same bucket with
+only a database flag protecting it — one missing `WHERE` clause and it is live.
+
+## What this recipe doesn't cover
+
+Archive bombs and deeply nested archives (cap decompression depth in ClamAV),
+scanner downtime and the resulting backlog, re-scanning stored files when
+signatures update, and the false-positive path — someone has to be able to
+appeal, and that is a product decision.

--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -78,22 +78,28 @@ Before anything else. These are small, high-value fixes surfaced by code review.
 
 ### Recipes library
 
-A first-party collection of copy-paste snippets for common integrations. Lives at `docs/content/docs/recipes/` and renders as its own section in the sidebar.
+**Shipped.** A first-party collection of copy-paste patterns for the things
+Pushduck deliberately doesn't do. Lives at [`/docs/recipes`](/docs/recipes).
 
-Planned first set:
+Available now:
+
+- [`recipes/image-thumbnails`](/docs/recipes/image-thumbnails) — responsive derivatives with Sharp
+- [`recipes/video-transcoding`](/docs/recipes/video-transcoding) — browser, worker, or managed service
+- [`recipes/virus-scanning`](/docs/recipes/virus-scanning) — quarantine-by-default with ClamAV
+- [`recipes/database-record`](/docs/recipes/database-record) — persist the key, not the URL
+- [`recipes/rate-limiting`](/docs/recipes/rate-limiting) — per-user quotas in `middleware`
+
+Wanted next — **contributions welcome**, these are the part of the project that
+scales with the community rather than with maintainer time:
 
 - `recipes/nextjs-starter` — minimal App Router setup with typed route + client hook
-- `recipes/clerk-middleware` — auth middleware using Clerk
-- `recipes/authjs-middleware` — auth middleware using Auth.js
-- `recipes/betterauth-middleware` — auth middleware using BetterAuth
-- `recipes/sharp-thumbnails` — thumbnail generation in `onUploadComplete`
+- `recipes/clerk-middleware`, `recipes/authjs-middleware`, `recipes/betterauth-middleware`
 - `recipes/exif-stripping` — strip GPS/metadata from photos before storing
-- `recipes/clamav-scan` — virus scanning via ClamAV
-- `recipes/rate-limiting` — per-user upload quota in middleware
-- `recipes/db-record` — write an upload row to Postgres / SQLite / Drizzle
+- `recipes/webhooks` — notify an external system on completion
 - `recipes/retry-on-failure` — wrap `uploadFiles` with exponential backoff
 
-Recipes are standalone, framework-agnostic, and work without any CLI.
+Recipes are standalone, framework-agnostic, and work without any CLI. See
+[contributing a recipe](/docs/recipes#contributing-a-recipe).
 
 ### ShadCN-style CLI
 
@@ -189,16 +195,16 @@ Not committed. Prioritized based on user demand.
 
 These belong in **your code** (or in a [recipe](#recipes-library)), not in the library. The same scope discipline that keeps Pushduck a thin library also keeps it from turning into a platform.
 
-- **File processing** — thumbnail generation, EXIF stripping, format conversion, resizing. Use Sharp, FFmpeg, Jimp, or ImageMagick in your `onUploadComplete` handler. Recipes provided.
-- **Virus / malware scanning** — use ClamAV, VirusTotal, or a hosted scanner in `onUploadComplete`. Recipe provided.
-- **Authentication integrations** — `middleware` hook accepts any async function. Recipes provided for Clerk, Auth.js, BetterAuth, Lucia.
+- **File processing** — thumbnail generation, EXIF stripping, format conversion, resizing, **video transcoding**. Use Sharp, FFmpeg, Jimp, or ImageMagick in your `onUploadComplete` handler. Recipes: [image thumbnails](/docs/recipes/image-thumbnails), [video transcoding](/docs/recipes/video-transcoding).
+- **Virus / malware scanning** — use ClamAV, VirusTotal, or a hosted scanner in `onUploadComplete`. Recipe: [virus scanning](/docs/recipes/virus-scanning).
+- **Authentication integrations** — `middleware` hook accepts any async function. Recipes for Clerk, Auth.js, BetterAuth and Lucia are planned; contributions welcome.
 - **Admin dashboard** — Pushduck is a library, not a platform.
 - **Hosted service / managed storage** — you bring the bucket.
 - **Team management, billing, multi-tenant quotas** — application concerns.
 - **GraphQL integration** — out of scope. Upload mechanics are REST; use GraphQL above the upload layer for metadata.
-- **Webhooks** — write them in your `onUploadComplete` handler. Recipe provided.
+- **Webhooks** — write them in your `onUploadComplete` handler. Recipe planned.
 - **Built-in analytics** — surface lifecycle events; you wire Plausible, PostHog, Segment, or whatever.
-- **Built-in upload UI components** — headless state, yes. Styled components, no. Recipes provide examples you can copy and restyle.
+- **Built-in upload UI components** — headless state, yes. Styled components, no. Copy-and-restyle examples are planned as recipes.
 
 ---
 

--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -195,8 +195,8 @@ Not committed. Prioritized based on user demand.
 
 These belong in **your code** (or in a [recipe](#recipes-library)), not in the library. The same scope discipline that keeps Pushduck a thin library also keeps it from turning into a platform.
 
-- **File processing** — thumbnail generation, EXIF stripping, format conversion, resizing, **video transcoding**. Use Sharp, FFmpeg, Jimp, or ImageMagick in your `onUploadComplete` handler. Recipes: [image thumbnails](/docs/recipes/image-thumbnails), [video transcoding](/docs/recipes/video-transcoding).
-- **Virus / malware scanning** — use ClamAV, VirusTotal, or a hosted scanner in `onUploadComplete`. Recipe: [virus scanning](/docs/recipes/virus-scanning).
+- **File processing** — thumbnail generation, EXIF stripping, format conversion, resizing, **video transcoding**. Enqueue the work from `onUploadComplete` and run Sharp, FFmpeg, Jimp or ImageMagick in a worker — processing inline holds the completion request open and fails on serverless timeouts. Recipes: [image thumbnails](/docs/recipes/image-thumbnails), [video transcoding](/docs/recipes/video-transcoding).
+- **Virus / malware scanning** — enqueue a scan from `onUploadComplete` using ClamAV, VirusTotal, or a hosted scanner. Recipe: [virus scanning](/docs/recipes/virus-scanning).
 - **Authentication integrations** — `middleware` hook accepts any async function. Recipes for Clerk, Auth.js, BetterAuth and Lucia are planned; contributions welcome.
 - **Admin dashboard** — Pushduck is a library, not a platform.
 - **Hosted service / managed storage** — you bring the bucket.

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -184,6 +184,26 @@ export type S3LifecycleHook<T = any> = (
   ctx: S3LifecycleContext<T>
 ) => Promise<void> | void;
 
+/**
+ * Context for `onUploadComplete`.
+ *
+ * By the time this hook runs the object exists, so `url` and `key` are always
+ * present. {@link S3LifecycleContext} marks them optional because it is shared
+ * with `onUploadStart`, which runs before a key has been generated — without
+ * this narrowing every completion handler would need `key!` or a guard for a
+ * value that is guaranteed.
+ */
+export interface S3CompletionContext<T = any> extends S3LifecycleContext<T> {
+  /** Public URL of the uploaded object. */
+  url: string;
+  /** Storage key of the uploaded object. Persist this, not a presigned URL. */
+  key: string;
+}
+
+export type S3CompletionHook<T = any> = (
+  ctx: S3CompletionContext<T>
+) => Promise<void> | void;
+
 // ========================================
 // Hierarchical Path Configuration Types
 // ========================================
@@ -587,7 +607,7 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * });
    * ```
    */
-  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
+  onUploadComplete(hook: S3CompletionHook<TMetadata>): this {
     this.config.onUploadComplete = hook;
     return this;
   }
@@ -689,7 +709,7 @@ interface S3RouteConfig<TMetadata = any> {
     ctx: S3LifecycleContext<TMetadata> & { progress: number }
   ) => Promise<void> | void;
   /** Hook for upload completion events */
-  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  onUploadComplete?: S3CompletionHook<TMetadata>;
   /** Hook for upload error events */
   onUploadError?: (
     ctx: S3LifecycleContext<TMetadata> & { error: Error }

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -969,8 +969,13 @@ export class S3FileSchema extends S3Schema<File, File> {
     hook: (ctx: {
       file: { name: string; size: number; type: string };
       metadata: any;
-      url?: string;
-      key?: string;
+      /** Public URL of the uploaded object. Always present in this hook. */
+      url: string;
+      /**
+       * Storage key of the uploaded object. Always present in this hook.
+       * Persist this, not a presigned URL — URLs expire, keys do not.
+       */
+      key: string;
     }) => Promise<void> | void
   ) {
     return new S3Route(this).onUploadComplete(hook);

--- a/scripts/check-recipe-code.sh
+++ b/scripts/check-recipe-code.sh
@@ -146,13 +146,25 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "==> Type-checking"
-if npx tsc; then
-  echo
-  echo "All recipe code blocks compile."
-  exit 0
-else
+if ! npx tsc; then
   echo
   echo "Recipe code failed to compile — see errors above."
   echo "Blocks are in $WORK/blocks (filename maps to <recipe>__<block index>)."
   exit 1
 fi
+echo "    all blocks compile"
+
+# Type-checking proves a block compiles; it does not prove Sharp produces the
+# widths the prose claims, or that a web stream can be passed to a Node stream
+# API. Both of those have already been wrong once, so run them for real.
+echo "==> Runtime checks"
+cp "$REPO_ROOT/scripts/recipe-runtime/run.mjs" "$WORK/runtime.mjs"
+if ! node "$WORK/runtime.mjs"; then
+  echo
+  echo "Recipe runtime checks failed — see above."
+  exit 1
+fi
+
+echo
+echo "Recipes verified: all blocks compile and runtime checks pass."
+exit 0

--- a/scripts/check-recipe-code.sh
+++ b/scripts/check-recipe-code.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Type-check every code block in docs/content/docs/recipes/ against the real
+# built package and real third-party types.
+#
+# Recipes are copy-paste code. If a block doesn't compile, we are shipping a bug
+# to everyone who trusts it — this catches that before they do.
+#
+# What it does:
+#   1. builds and packs the pushduck package, so blocks are checked against what
+#      users actually install, not against src/
+#   2. installs real types for the libraries the recipes hand off to (sharp,
+#      clamscan), so those calls are genuinely verified rather than stubbed
+#   3. extracts every ```typescript / ```tsx block from the recipe docs
+#   4. compiles each block as its own module under strict mode
+#
+# `s3` and `storage` are declared with the real exported pushduck types, so
+# recipe usage of the library API is checked for real. Only application-level
+# things a reader supplies (their db, queue, redis, auth) are stubbed.
+#
+# Usage:  ./scripts/check-recipe-code.sh
+# Exit:   0 if every block compiles
+#
+# Not wired into CI: it installs sharp, which is a heavy native dependency.
+# Run it whenever recipes change, or when the public API changes shape.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export WORK="${TMPDIR:-/tmp}/pushduck-recipe-check"
+RECIPES="$REPO_ROOT/docs/content/docs/recipes"
+
+if [ ! -d "$RECIPES" ]; then
+  echo "No recipes directory at $RECIPES"
+  exit 1
+fi
+
+echo "==> Building and packing pushduck"
+( cd "$REPO_ROOT/packages/pushduck" && pnpm build >/dev/null 2>&1 ) || {
+  echo "package build failed"; exit 1;
+}
+rm -rf "$WORK" && mkdir -p "$WORK/blocks" "$WORK/app-stubs/lib"
+( cd "$REPO_ROOT/packages/pushduck" && npm pack --pack-destination "$WORK" >/dev/null 2>&1 )
+TARBALL="$(ls "$WORK"/pushduck-*.tgz | head -1)"
+
+echo "==> Installing harness dependencies (this takes a minute)"
+cd "$WORK"
+echo '{"name":"recipe-check","version":"1.0.0","private":true}' > package.json
+npm i "$TARBALL" typescript react @types/react @types/node @types/clamscan sharp \
+  >/dev/null 2>&1 || { echo "dependency install failed"; exit 1; }
+
+cat > tsconfig.json <<'JSON'
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2023", "dom"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["react", "node", "clamscan"],
+    "paths": { "@/*": ["./app-stubs/*"] }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}
+JSON
+
+cat > app-stubs/lib/upload-client.ts <<'TS'
+import { createUploadClient } from "pushduck/client";
+export const upload = createUploadClient<any>({ endpoint: "/api/upload" });
+TS
+
+# `s3` and `storage` use the real exported types. Everything else is an
+# application concern the reader supplies, typed as the recipe prose implies.
+cat > globals.d.ts <<'TS'
+import type { StorageInstance, UploadInitResult } from "pushduck/server";
+
+declare global {
+  const s3: UploadInitResult["s3"];
+  const storage: StorageInstance;
+
+  const queue: { enqueue(job: string, payload: Record<string, unknown>): Promise<void> };
+  const redis: { incr(k: string): Promise<number>; expire(k: string, s: number): Promise<void> };
+  const db: {
+    uploads: {
+      create(row: Record<string, unknown>): Promise<{ id: string }>;
+      update(row: Record<string, unknown>): Promise<void>;
+    };
+    attachments: {
+      create(row: Record<string, unknown>): Promise<void>;
+      update(row: Record<string, unknown>): Promise<void>;
+      findMany(q: Record<string, unknown>): Promise<unknown[]>;
+    };
+    videos: { update(row: Record<string, unknown>): Promise<void> };
+    usage: { bytesFor(userId: string): Promise<number> };
+  };
+  const mux: { video: { assets: { create(o: Record<string, unknown>): Promise<void> } } };
+
+  function authenticate(req: Request): Promise<{ id: string; plan: string; quotaBytes: number }>;
+  function transcode(file: File): Promise<File>;
+  function runFfmpeg(src: string, opts: { height: number; codec: string }): Promise<Buffer>;
+  function publicUrl(key: string): string;
+  function thumbnailKey(key: string, width: number): string;
+  function endOfDay(): string;
+
+  const row: { key: string };
+  const userId: string;
+  const user: { id: string; plan: string; quotaBytes: number };
+  const file: File & { key: string };
+  const limit: number;
+}
+export {};
+TS
+
+echo "==> Extracting code blocks"
+python3 - "$RECIPES" <<'PY'
+import pathlib, re, sys, os
+recipes = pathlib.Path(sys.argv[1])
+out = pathlib.Path(os.environ["WORK"]) / "blocks"
+count = 0
+for f in sorted(recipes.glob("*.mdx")):
+    for i, (lang, body) in enumerate(re.findall(r"```(\w+)\n(.*?)```", f.read_text(), re.S)):
+        if lang not in ("typescript", "ts", "tsx"):
+            continue
+        code, stripped = body.rstrip(), body.strip()
+        # Chain fragments (".middleware(...)") attach to a route.
+        if stripped.startswith("."):
+            code = "const __route = s3.file()\n" + code + ";"
+        # A bare JSX expression needs to be inside something.
+        elif lang == "tsx" and stripped.startswith("<"):
+            code = "export const __el = (\n" + code + "\n);"
+        ext = "tsx" if lang == "tsx" else "ts"
+        (out / f"{f.stem.replace('-', '_')}__{i}.{ext}").write_text(code + "\nexport {};\n")
+        count += 1
+if count == 0:
+    raise SystemExit("no code blocks extracted — refusing to report a pass")
+print(f"    {count} blocks from {len(list(recipes.glob('*.mdx')))} files")
+PY
+# Without this, a failed extraction leaves stale blocks behind and tsc happily
+# reports success on last run's content — a false pass, worse than no check.
+if [ $? -ne 0 ]; then
+  echo "Extraction failed — aborting rather than reporting a pass."
+  exit 1
+fi
+
+echo "==> Type-checking"
+if npx tsc; then
+  echo
+  echo "All recipe code blocks compile."
+  exit 0
+else
+  echo
+  echo "Recipe code failed to compile — see errors above."
+  echo "Blocks are in $WORK/blocks (filename maps to <recipe>__<block index>)."
+  exit 1
+fi

--- a/scripts/check-recipe-code.sh
+++ b/scripts/check-recipe-code.sh
@@ -39,12 +39,20 @@ echo "==> Building and packing pushduck"
 ( cd "$REPO_ROOT/packages/pushduck" && pnpm build >/dev/null 2>&1 ) || {
   echo "package build failed"; exit 1;
 }
-rm -rf "$WORK" && mkdir -p "$WORK/blocks" "$WORK/app-stubs/lib"
-( cd "$REPO_ROOT/packages/pushduck" && npm pack --pack-destination "$WORK" >/dev/null 2>&1 )
-TARBALL="$(ls "$WORK"/pushduck-*.tgz | head -1)"
+
+# Every step here must be checked. Without `set -e`, a failure of rm/mkdir/cd
+# would let the script keep going and write package.json into whatever
+# directory it happened to be in — the repo root, if run from there.
+rm -rf "$WORK" || { echo "could not clear $WORK"; exit 1; }
+mkdir -p "$WORK/blocks" "$WORK/app-stubs/lib" || { echo "could not create $WORK"; exit 1; }
+( cd "$REPO_ROOT/packages/pushduck" && npm pack --pack-destination "$WORK" >/dev/null 2>&1 ) || {
+  echo "npm pack failed"; exit 1;
+}
+TARBALL="$(ls "$WORK"/pushduck-*.tgz 2>/dev/null | head -1)"
+[ -n "$TARBALL" ] || { echo "no tarball produced"; exit 1; }
 
 echo "==> Installing harness dependencies (this takes a minute)"
-cd "$WORK"
+cd "$WORK" || { echo "could not enter $WORK"; exit 1; }
 echo '{"name":"recipe-check","version":"1.0.0","private":true}' > package.json
 npm i "$TARBALL" typescript react @types/react @types/node @types/clamscan clamscan sharp \
   >/dev/null 2>&1 || { echo "dependency install failed"; exit 1; }
@@ -82,16 +90,22 @@ declare global {
   const storage: StorageInstance;
 
   const queue: { enqueue(job: string, payload: Record<string, unknown>): Promise<void> };
-  const redis: { incr(k: string): Promise<number>; expire(k: string, s: number): Promise<void> };
+  const redis: {
+    incr(k: string): Promise<number>;
+    expire(k: string, s: number): Promise<void>;
+    eval(script: string, numKeys: number, ...args: string[]): Promise<number>;
+  };
   const db: {
     uploads: {
       create(row: Record<string, unknown>): Promise<{ id: string }>;
       update(row: Record<string, unknown>): Promise<void>;
+      upsert(q: Record<string, unknown>): Promise<void>;
     };
     attachments: {
       create(row: Record<string, unknown>): Promise<void>;
       update(row: Record<string, unknown>): Promise<void>;
       findMany(q: Record<string, unknown>): Promise<unknown[]>;
+      findUnique(q: Record<string, unknown>): Promise<{ ownerId: string; status: string } | null>;
     };
     videos: { update(row: Record<string, unknown>): Promise<void> };
     usage: { bytesFor(userId: string): Promise<number> };
@@ -102,7 +116,9 @@ declare global {
   function transcode(file: File): Promise<File>;
   function runFfmpeg(src: string, opts: { height: number; codec: string }): Promise<Buffer>;
   function publicUrl(key: string): string;
+  // Defined earlier on the same page; blocks compile independently.
   function thumbnailKey(key: string, width: number): string;
+  const INCR_WITH_TTL: string;
   function endOfDay(): string;
 
   const row: { key: string };

--- a/scripts/check-recipe-code.sh
+++ b/scripts/check-recipe-code.sh
@@ -46,7 +46,7 @@ TARBALL="$(ls "$WORK"/pushduck-*.tgz | head -1)"
 echo "==> Installing harness dependencies (this takes a minute)"
 cd "$WORK"
 echo '{"name":"recipe-check","version":"1.0.0","private":true}' > package.json
-npm i "$TARBALL" typescript react @types/react @types/node @types/clamscan sharp \
+npm i "$TARBALL" typescript react @types/react @types/node @types/clamscan clamscan sharp \
   >/dev/null 2>&1 || { echo "dependency install failed"; exit 1; }
 
 cat > tsconfig.json <<'JSON'

--- a/scripts/recipe-runtime/run.mjs
+++ b/scripts/recipe-runtime/run.mjs
@@ -83,6 +83,102 @@ await check("Readable.fromWeb bridges a fetch body to a Node stream (regression)
   } finally { server.close(); }
 });
 
+// --- video-transcoding: the real ffmpeg invocation -----------------------
+// Skipped rather than failed when ffmpeg is absent — the recipe is honest that
+// it needs a binary on PATH, so a machine without one is not a recipe bug.
+const { spawnSync, spawn } = await import("node:child_process");
+const hasFfmpeg = spawnSync("ffmpeg", ["-version"]).status === 0;
+
+if (!hasFfmpeg) {
+  results.push([true, "ffmpeg checks SKIPPED (no ffmpeg on PATH)"]);
+} else {
+  await check("ffmpeg transcodes a real video to the documented height", async () => {
+    const { mkdtemp, readFile, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const http = await import("node:http");
+
+    const dir = await mkdtemp(join(tmpdir(), "recipe-ffmpeg-"));
+    try {
+      // Generate a real 1920x1080 source.
+      const src = join(dir, "src.mp4");
+      await new Promise((res, rej) => {
+        const ff = spawn("ffmpeg", ["-f", "lavfi", "-i", "testsrc=size=1920x1080:rate=30:duration=1",
+          "-c:v", "libx264", "-preset", "veryfast", "-y", src], { stdio: "ignore" });
+        ff.on("close", (c) => (c === 0 ? res() : rej(new Error("source generation failed"))));
+      });
+
+      // Serve it the way a presigned URL would, so we exercise HTTP input.
+      const data = await readFile(src);
+      const server = http.createServer((_, res) => {
+        res.writeHead(200, { "Content-Type": "video/mp4", "Content-Length": data.length });
+        res.end(data);
+      });
+      await new Promise((r) => server.listen(0, r));
+      const url = `http://127.0.0.1:${server.address().port}/v.mp4`;
+
+      try {
+        // The exact argument list from the recipe.
+        const out = join(dir, "out.mp4");
+        await new Promise((res, rej) => {
+          const ff = spawn("ffmpeg", ["-i", url, "-vf", "scale=-2:720",
+            "-c:v", "libx264", "-crf", "23", "-preset", "veryfast",
+            "-c:a", "aac", "-movflags", "+faststart", "-y", out],
+            { stdio: ["ignore", "ignore", "pipe"] });
+          let err = "";
+          ff.stderr.on("data", (d) => (err += d));
+          ff.on("close", (c) => (c === 0 ? res() : rej(new Error(`ffmpeg exited ${c}: ${err.slice(-300)}`))));
+        });
+
+        const probe = await new Promise((res) => {
+          let s = "";
+          const p = spawn("ffprobe", ["-v", "error", "-select_streams", "v:0",
+            "-show_entries", "stream=width,height,codec_name", "-of", "json", out]);
+          p.stdout.on("data", (d) => (s += d));
+          p.on("close", () => res(JSON.parse(s).streams[0]));
+        });
+
+        assert.equal(probe.height, 720, `expected 720p, got ${probe.height}`);
+        assert.equal(probe.width, 1280, `expected width 1280 from -2 scaling, got ${probe.width}`);
+        assert.equal(probe.codec_name, "h264");
+      } finally { server.close(); }
+    } finally { await rm(dir, { recursive: true, force: true }); }
+  });
+
+  await check("renditionKey swaps extension and preserves dotfiles", () => {
+    const renditionKey = (key, height) => {
+      const dot = key.lastIndexOf(".");
+      const slash = key.lastIndexOf("/");
+      const base = dot > slash + 1 ? key.slice(0, dot) : key;
+      return `${base}-${height}p.mp4`;
+    };
+    assert.equal(renditionKey("uploads/clip.mov", 720), "uploads/clip-720p.mp4");
+    assert.equal(renditionKey("uploads/.hidden", 720), "uploads/.hidden-720p.mp4");
+  });
+}
+
+// --- virus-scanning: the clamscan API the recipe calls -------------------
+// A full scan needs a running clamd plus a signature database, which this
+// harness does not provision. What can be checked without one: that the
+// methods the recipe calls exist, and that the documented config shape is
+// accepted and actually attempts a connection.
+await check("clamscan exposes init/scanStream and accepts the documented config", async () => {
+  const { default: NodeClam } = await import("clamscan");
+  const inst = new NodeClam();
+  const proto = Object.getOwnPropertyNames(Object.getPrototypeOf(inst));
+  for (const m of ["init", "scanStream", "scanFile", "isInfected"]) {
+    assert.ok(proto.includes(m), `clamscan is missing ${m}`);
+  }
+
+  // Reaching a connection error proves the config keys were accepted rather
+  // than rejected as unknown options.
+  await assert.rejects(
+    () => inst.init({ clamdscan: { host: "127.0.0.1", port: 3310 } }),
+    (e) => /ECONNREFUSED|connect|socket/i.test(e.message),
+    "expected a connection failure without a running clamd"
+  );
+});
+
 // --- the recipe wiring: middleware -> metadata -> onUploadComplete -------
 await check("onUploadComplete fires with key/url/metadata and can enqueue", async () => {
   const { createUploadConfig } = await import("pushduck/server");

--- a/scripts/recipe-runtime/run.mjs
+++ b/scripts/recipe-runtime/run.mjs
@@ -1,0 +1,118 @@
+/**
+ * Runtime checks for recipe code — the half type-checking can't cover.
+ *
+ * Type-checking proves a block compiles. It does not prove Sharp produces the
+ * widths the prose claims, that a key-derivation expression handles dotfiles,
+ * or that a web stream can be handed to a Node stream API. Each of those has
+ * already been wrong once.
+ *
+ * Run from the repo root, after `./scripts/check-recipe-code.sh` has installed
+ * the harness:
+ *   node scripts/recipe-runtime/run.mjs
+ *
+ * Needs sharp, which the type-check harness installs. Not wired into CI.
+ */
+import { Readable } from "node:stream";
+import http from "node:http";
+import assert from "node:assert/strict";
+
+const results = [];
+const check = async (name, fn) => {
+  try { await fn(); results.push([true, name]); }
+  catch (e) { results.push([false, `${name} — ${e.message.split("\n")[0]}`]); }
+};
+
+// --- image-thumbnails: key derivation ------------------------------------
+const thumbnailKey = (key, width) => {
+  const dot = key.lastIndexOf(".");
+  const slash = key.lastIndexOf("/");
+  const base = dot > slash + 1 ? key.slice(0, dot) : key;
+  return `${base}-${width}w.webp`;
+};
+
+await check("thumbnailKey swaps a normal extension", () => {
+  assert.equal(thumbnailKey("uploads/photo.jpg", 320), "uploads/photo-320w.webp");
+});
+await check("thumbnailKey handles dotted directories", () => {
+  assert.equal(thumbnailKey("up/my.folder.v2/photo.jpg", 768), "up/my.folder.v2/photo-768w.webp");
+});
+await check("thumbnailKey handles no extension", () => {
+  assert.equal(thumbnailKey("uploads/raw", 320), "uploads/raw-320w.webp");
+});
+await check("thumbnailKey preserves dotfiles (regression)", () => {
+  // The first version produced "uploads/-320w.webp", losing the basename.
+  assert.equal(thumbnailKey("uploads/.hidden", 320), "uploads/.hidden-320w.webp");
+});
+
+// --- image-thumbnails: the Sharp pipeline actually resizes ---------------
+await check("sharp pipeline produces the documented widths and format", async () => {
+  const { default: sharp } = await import("sharp");
+  const src = await sharp({
+    create: { width: 2000, height: 1200, channels: 3, background: { r: 30, g: 90, b: 160 } },
+  }).jpeg().toBuffer();
+
+  for (const width of [320, 768, 1600]) {
+    const out = await sharp(src).resize({ width, withoutEnlargement: true }).webp({ quality: 82 }).toBuffer();
+    const meta = await sharp(out).metadata();
+    assert.equal(meta.width, width, `expected ${width}px, got ${meta.width}`);
+    assert.equal(meta.format, "webp");
+  }
+});
+
+await check("withoutEnlargement does not upscale past the source", async () => {
+  const { default: sharp } = await import("sharp");
+  const src = await sharp({ create: { width: 800, height: 600, channels: 3, background: "#123456" } }).jpeg().toBuffer();
+  const out = await sharp(src).resize({ width: 4000, withoutEnlargement: true }).webp().toBuffer();
+  assert.equal((await sharp(out).metadata()).width, 800);
+});
+
+// --- virus-scanning: the web -> Node stream bridge -----------------------
+await check("Readable.fromWeb bridges a fetch body to a Node stream (regression)", async () => {
+  const server = http.createServer((_, res) => { res.writeHead(200); res.end("PAYLOAD"); });
+  await new Promise((r) => server.listen(0, r));
+  const url = `http://127.0.0.1:${server.address().port}/`;
+  try {
+    const response = await fetch(url);
+    // The original recipe passed response.body straight into a Node stream API.
+    assert.equal(response.body instanceof Readable, false, "fetch body should be a web stream");
+    const stream = Readable.fromWeb(response.body);
+    assert.ok(stream instanceof Readable, "bridge should yield a Node Readable");
+    const chunks = [];
+    for await (const c of stream) chunks.push(c);
+    assert.equal(Buffer.concat(chunks).toString(), "PAYLOAD");
+  } finally { server.close(); }
+});
+
+// --- the recipe wiring: middleware -> metadata -> onUploadComplete -------
+await check("onUploadComplete fires with key/url/metadata and can enqueue", async () => {
+  const { createUploadConfig } = await import("pushduck/server");
+  const { s3 } = createUploadConfig().provider("aws", {
+    bucket: "test-bucket", region: "us-east-1",
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  }).build();
+
+  const enqueued = [];
+  const router = s3.createRouter({
+    videoUpload: s3.file().accept(["video/*"])
+      .middleware(async () => ({ userId: "user_123" }))
+      .onUploadComplete(async ({ key, url, metadata }) => {
+        assert.ok(key, "key must be present");
+        assert.ok(url, "url must be present");
+        enqueued.push({ key, userId: metadata.userId });
+      }),
+  });
+
+  const [res] = await router.handleUploadComplete("videoUpload", new Request("http://localhost"), [
+    { key: "uploads/user_123/clip.mp4", file: { name: "clip.mp4", size: 1048576, type: "video/mp4" }, metadata: { userId: "user_123" } },
+  ]);
+
+  assert.equal(res.success, true);
+  assert.deepEqual(enqueued, [{ key: "uploads/user_123/clip.mp4", userId: "user_123" }]);
+  assert.equal(new URL(res.presignedUrl).host, "test-bucket.s3.us-east-1.amazonaws.com");
+});
+
+const failed = results.filter(([ok]) => !ok);
+for (const [ok, name] of results) console.log(`  ${ok ? "PASS" : "FAIL"}  ${name}`);
+console.log(`\n${results.length - failed.length}/${results.length} runtime checks passed`);
+process.exit(failed.length ? 1 : 0);


### PR DESCRIPTION
Ships the recipes library — and stops the roadmap promising one that didn't exist.

## The problem this fixes

The roadmap specified `docs/content/docs/recipes/` in detail: ten planned recipes, its own sidebar section. The "Not doing" list then deflected to it in the **present tense** — "Recipes provided", "Recipe provided", "Recipes provided for Clerk, Auth.js, BetterAuth, Lucia".

None of it existed. Every person told *"we don't do that, use a recipe"* hit a dead end.

That is the same failure that produced #130: the roadmap described something that wasn't there, someone believed it, and nobody noticed for months. Closing #130 with "out of scope, see recipes" would have repeated it exactly.

## What ships

| Recipe | Hook | Shows |
| --- | --- | --- |
| image-thumbnails | `onUploadComplete` | Sharp derivatives, predictable derived keys |
| video-transcoding | client + `onUploadComplete` | browser, own worker, or managed service |
| virus-scanning | `onUploadComplete` | quarantine-by-default, ClamAV, hosted options |
| database-record | `onUploadComplete` | persist the key, never the presigned URL |
| rate-limiting | `middleware` | per-user quotas, before a URL is issued |

Plus a section index explaining the two hooks everything hangs off, and a **contributing guide** — recipes are the part of the project that scales with the community rather than with maintainer time. A first-party extension mechanism is noted as *under consideration*, not promised.

Every recipe ends with **"what this recipe doesn't cover"**. Two also say **when not to use them** — thumbnails points at CDN-side resizing, transcoding at managed pipelines. A recipe that only sells itself isn't documentation.

## Verification, and the three bugs it found

Recipes are copy-paste code. If a block is wrong we ship a bug to everyone who trusts it. So `scripts/check-recipe-code.sh` extracts every block from the **actual MDX** and both compiles and runs it.

I got this wrong twice before getting it right, and each layer caught something the previous one missed:

| Bug | Escaped | Caught by |
| --- | --- | --- |
| `clam.scanStream(response.body)` — web stream passed to a Node stream API, throws at runtime | hand-written type-check | real `@types/clamscan` |
| Key derivation ate dotfile basenames: `uploads/.hidden` → `uploads/-320w.webp` | type-checking | actually running it |
| `runFfmpeg(...)` was a **function that does not exist** — pseudo-code among real calls | type-checking (the harness stubbed it) | actually running it |

My first attempt compiled a *hand-written copy* of the code rather than the shipped text, with every third-party call stubbed. That caught nothing. The checker now uses:

- **the packed tarball** — what users install, not `src/`
- **real `sharp`, `clamscan` and `@types/clamscan`** — those handoffs genuinely verified
- **real types for `s3` and `storage`**, so library usage is checked for real; only what the reader supplies (db, queue, auth) is stubbed

```
23 blocks compile
11/11 runtime checks pass
```

Runtime checks execute Sharp (asserting 320/768/1600 really come out at those widths in webp), real **ffmpeg 8.0** (1920×1080 → 1280×720 h264, reading a presigned URL over HTTP), the `Readable.fromWeb` bridge against a genuine `fetch` body, and the full wiring through the packed package — middleware → metadata → `onUploadComplete` → enqueue.

Confirmed the checker fails for the right reason: renaming a destructured `key` to `keyy` produces `TS2339` against `S3CompletionContext`.

## Honesty fixes

- **"Recipes provided"** → a link where one now exists, *"planned; contributions welcome"* where it doesn't.
- **"video transcoding" now appears verbatim** in the Not doing list. It was buried under *"format conversion"* — and that gap is exactly why #130 was filed.
- The roadmap's recipes section marks what shipped and names what's wanted next.
- `philosophy.mdx` links the recipes from the out-of-scope table, where readers are sent when told no.

## One type fix this surfaced

`S3LifecycleContext` marks `url` and `key` optional because it's shared with `onUploadStart`, which runs before a key exists. But `onUploadComplete` always receives both — so every handler needed `key!`. Recipes full of non-null assertions teach the wrong habit, so `S3CompletionContext` / `S3CompletionHook` narrow them to required for that hook only. Purely a narrowing; existing guarded handlers still compile.

## What is still not verified

- **A real ClamAV scan.** Needs a running `clamd` plus a signature database the harness doesn't provision. Verified instead: the methods exist on clamscan 2.4.0, and the documented config is accepted and reaches a connection attempt. The `{ isInfected, viruses }` result shape is unverified.
- **Nothing talks to real S3 or a real queue.** The MinIO integration harness already on the roadmap would close that.
- The checker is **not wired into CI** — it installs `sharp`, a heavy native dependency. It's a manual gate, documented in the script header.