### PR TITLE
feat(errors): add an ecosystem-neutral error type and wire format

### DIFF
--- a/packages/pushduck/src/__tests__/upload-error.test.ts
+++ b/packages/pushduck/src/__tests__/upload-error.test.ts
@@ -1,0 +1,325 @@
+/**
+ * @fileoverview Tests for the ecosystem-neutral error type and wire format.
+ *
+ * The contract these pin down is deliberately built on standards rather than
+ * any framework's conventions:
+ *
+ * - status codes follow RFC 9110, so proxies and every HTTP client agree
+ * - the body follows RFC 9457, so non-TypeScript ports can parse it
+ * - `cause` follows ES2022, so the underlying failure is never flattened
+ * - `code` is a plain string union, so narrowing needs no library
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  codeForStatus,
+  fromProblemDetails,
+  isUploadError,
+  PROBLEM_JSON_MEDIA_TYPE,
+  toProblemDetails,
+  toProblemResponse,
+  toUploadError,
+  UPLOAD_ERROR_CODES,
+  UploadError,
+} from "../core/errors";
+
+describe("UploadError", () => {
+  it("derives status, title and retryability from the code", () => {
+    const error = new UploadError("FILE_TOO_LARGE");
+
+    expect(error.status).toBe(413);
+    expect(error.title).toBe("File exceeds the maximum size");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toBe("File exceeds the maximum size");
+  });
+
+  it("is a real Error, so existing catch blocks keep working", () => {
+    const error = new UploadError("UNAUTHORIZED");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("UploadError");
+    expect(typeof error.stack).toBe("string");
+  });
+
+  it("preserves the underlying failure via ES2022 `cause`", () => {
+    // Flattening the original into a string would lose the stack and any
+    // provider-specific fields — the thing you actually need when debugging.
+    const original = new Error("ECONNREFUSED");
+    const error = new UploadError("NETWORK_ERROR", "Could not reach storage", {
+      cause: original,
+    });
+
+    expect(error.cause).toBe(original);
+  });
+
+  it("carries structured meta rather than only a message", () => {
+    const error = new UploadError("QUOTA_EXCEEDED", "Monthly limit reached", {
+      meta: { limit: 100, used: 100, resetsAt: "2026-09-01" },
+    });
+
+    expect(error.meta).toEqual({
+      limit: 100,
+      used: 100,
+      resetsAt: "2026-09-01",
+    });
+  });
+
+  it("exposes a documentation URI derived from the code", () => {
+    expect(new UploadError("FILE_TOO_LARGE").type).toBe(
+      "https://pushduck.org/errors/file-too-large"
+    );
+  });
+
+  it("classifies storage credential failures as 502, not 403", () => {
+    // A 403 would tell the caller to re-authenticate, but the caller is fine —
+    // *our* credentials are the problem.
+    const error = new UploadError("STORAGE_ACCESS_DENIED");
+
+    expect(error.status).toBe(502);
+    expect(error.isClientError).toBe(false);
+  });
+
+  it("marks throttling and upstream failures as retryable", () => {
+    expect(new UploadError("RATE_LIMITED").retryable).toBe(true);
+    expect(new UploadError("STORAGE_UNAVAILABLE").retryable).toBe(true);
+    expect(new UploadError("TIMEOUT").retryable).toBe(true);
+
+    expect(new UploadError("FILE_TOO_LARGE").retryable).toBe(false);
+    expect(new UploadError("UNAUTHORIZED").retryable).toBe(false);
+  });
+
+  it("keeps every code's status in the right class", () => {
+    // Guards the table itself: a typo here would silently misroute a failure.
+    for (const [code, def] of Object.entries(UPLOAD_ERROR_CODES)) {
+      expect(def.status, `${code} status`).toBeGreaterThanOrEqual(400);
+      expect(def.status, `${code} status`).toBeLessThan(600);
+      expect(def.title.length, `${code} title`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("isUploadError", () => {
+  it("recognises an UploadError", () => {
+    expect(isUploadError(new UploadError("UNAUTHORIZED"))).toBe(true);
+  });
+
+  it("rejects a plain Error and non-errors", () => {
+    expect(isUploadError(new Error("nope"))).toBe(false);
+    expect(isUploadError("nope")).toBe(false);
+    expect(isUploadError(null)).toBe(false);
+  });
+
+  it("recognises a structurally identical error from another package copy", () => {
+    // Duplicate installs and cross-realm values break `instanceof`; the guard
+    // is structural so it keeps working.
+    const foreign = new Error("dup");
+    Object.assign(foreign, {
+      name: "UploadError",
+      code: "UNAUTHORIZED",
+      status: 401,
+    });
+
+    expect(isUploadError(foreign)).toBe(true);
+  });
+});
+
+describe("toUploadError", () => {
+  it("passes an UploadError through unchanged", () => {
+    const original = new UploadError("FORBIDDEN");
+    expect(toUploadError(original)).toBe(original);
+  });
+
+  it("treats a bare Error as an internal error, preserving it as cause", () => {
+    // A `throw new Error()` from user middleware is an unhandled exception, so
+    // 500 is the honest reading — but the original must not be lost.
+    const original = new Error("something broke");
+    const converted = toUploadError(original);
+
+    expect(converted.code).toBe("INTERNAL_ERROR");
+    expect(converted.status).toBe(500);
+    expect(converted.message).toBe("something broke");
+    expect(converted.cause).toBe(original);
+  });
+
+  it("handles non-Error throws", () => {
+    expect(toUploadError("a string").code).toBe("INTERNAL_ERROR");
+    expect(toUploadError({ weird: true }).message).toBe("[object Object]");
+  });
+
+  it("accepts an explicit fallback code", () => {
+    expect(toUploadError(new Error("x"), "VALIDATION_FAILED").code).toBe(
+      "VALIDATION_FAILED"
+    );
+  });
+});
+
+describe("RFC 9457 serialisation", () => {
+  it("emits every standard member plus pushduck's extensions", () => {
+    const error = new UploadError("FILE_TOO_LARGE", "photo.jpg is 9 MB", {
+      meta: { limit: 5242880, actual: 9437184 },
+      instance: "/api/upload?route=imageUpload",
+    });
+
+    expect(toProblemDetails(error)).toEqual({
+      type: "https://pushduck.org/errors/file-too-large",
+      title: "File exceeds the maximum size",
+      status: 413,
+      detail: "photo.jpg is 9 MB",
+      instance: "/api/upload?route=imageUpload",
+      code: "FILE_TOO_LARGE",
+      retryable: false,
+      meta: { limit: 5242880, actual: 9437184 },
+      // Legacy mirror of `detail` for pre-0.7 clients.
+      error: "photo.jpg is 9 MB",
+    });
+  });
+
+  it("passes 4xx detail through — it describes the caller's own request", () => {
+    const problem = toProblemDetails(
+      new UploadError("VALIDATION_FAILED", "png is not accepted", {
+        meta: { accepted: ["image/jpeg"] },
+      })
+    );
+
+    expect(problem.detail).toBe("png is not accepted");
+    expect(problem.meta).toEqual({ accepted: ["image/jpeg"] });
+  });
+
+  it("redacts 5xx detail and meta by default", () => {
+    // A server-side failure may name buckets, hosts, or upstream internals.
+    const problem = toProblemDetails(
+      new UploadError("INTERNAL_ERROR", "connection to db-prod-7 refused", {
+        meta: { host: "db-prod-7.internal" },
+      })
+    );
+
+    expect(problem.detail).toBe("Internal error");
+    expect(problem.detail).not.toContain("db-prod-7");
+    expect(problem.meta).toBeUndefined();
+  });
+
+  it("includes 5xx detail when debug is enabled", () => {
+    const problem = toProblemDetails(
+      new UploadError("INTERNAL_ERROR", "connection refused", {
+        meta: { host: "db" },
+      }),
+      { debug: true }
+    );
+
+    expect(problem.detail).toBe("connection refused");
+    expect(problem.meta).toEqual({ host: "db" });
+  });
+
+  it("builds a Response with the RFC 9457 media type and status", async () => {
+    const response = toProblemResponse(new UploadError("UNAUTHORIZED"));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Content-Type")).toBe(PROBLEM_JSON_MEDIA_TYPE);
+    expect((await response.json()).code).toBe("UNAUTHORIZED");
+  });
+});
+
+describe("RFC 9457 deserialisation", () => {
+  it("round-trips an error through the wire format", () => {
+    const original = new UploadError("QUOTA_EXCEEDED", "Limit reached", {
+      meta: { limit: 100 },
+    });
+
+    const revived = fromProblemDetails(toProblemDetails(original));
+
+    expect(revived.code).toBe("QUOTA_EXCEEDED");
+    expect(revived.status).toBe(429);
+    expect(revived.retryable).toBe(true);
+    expect(revived.message).toBe("Limit reached");
+    expect(revived.meta).toEqual({ limit: 100 });
+  });
+
+  it("falls back to the HTTP status when the body carries no code", () => {
+    // An nginx 502 or a CDN error page is not a problem document, but the
+    // client must still produce a usable, correctly-classified error.
+    const revived = fromProblemDetails("<html>Bad Gateway</html>", 502);
+
+    expect(revived.code).toBe("STORAGE_UNAVAILABLE");
+    expect(revived.retryable).toBe(true);
+  });
+
+  it("understands the pre-RFC error shape from older servers", () => {
+    // Older pushduck servers returned `{ success: false, error: "..." }`.
+    const revived = fromProblemDetails({ error: "Route not found" }, 404);
+
+    expect(revived.code).toBe("NOT_FOUND");
+    expect(revived.message).toBe("Route not found");
+  });
+
+  it("ignores an unrecognised code rather than trusting it", () => {
+    const revived = fromProblemDetails({ code: "NOT_A_REAL_CODE" }, 403);
+    expect(revived.code).toBe("FORBIDDEN");
+  });
+
+  it("never throws while handling a malformed error", () => {
+    expect(() => fromProblemDetails(null, undefined)).not.toThrow();
+    expect(() => fromProblemDetails(undefined)).not.toThrow();
+    expect(fromProblemDetails(null).code).toBe("INTERNAL_ERROR");
+  });
+});
+
+describe("codeForStatus", () => {
+  it("maps well-known statuses", () => {
+    expect(codeForStatus(401)).toBe("UNAUTHORIZED");
+    expect(codeForStatus(413)).toBe("PAYLOAD_TOO_LARGE");
+    expect(codeForStatus(429)).toBe("RATE_LIMITED");
+    expect(codeForStatus(504)).toBe("TIMEOUT");
+  });
+
+  it("falls back by status class", () => {
+    expect(codeForStatus(418)).toBe("BAD_REQUEST");
+    expect(codeForStatus(500)).toBe("INTERNAL_ERROR");
+    expect(codeForStatus(undefined)).toBe("INTERNAL_ERROR");
+  });
+});
+
+describe("ecosystem neutrality", () => {
+  it("maps to any framework's vocabulary in a few lines, in their code", () => {
+    // The point of the design: consumers translate our stable codes into
+    // whatever their ecosystem wants. pushduck ships none of these mappings,
+    // so an upstream rename is never our breaking change.
+    const error = new UploadError("QUOTA_EXCEEDED");
+
+    // tRPC-style
+    const trpcCode = ({ 401: "UNAUTHORIZED", 429: "TOO_MANY_REQUESTS" } as const)[
+      error.status as 401 | 429
+    ];
+    expect(trpcCode).toBe("TOO_MANY_REQUESTS");
+
+    // retry policies
+    expect(error.retryable).toBe(true);
+
+    // plain TypeScript narrowing, no library
+    if (error.code === "QUOTA_EXCEEDED") {
+      expect(error.status).toBe(429);
+    }
+  });
+});
+
+describe("backward compatibility with pre-0.7 clients", () => {
+  it("still emits the legacy `error` field", () => {
+    // A client older than the RFC 9457 change reads `body.error`. Without this
+    // it would fall back to "Server error: <statusText>" and lose the message
+    // whenever a server is deployed ahead of its clients.
+    const problem = toProblemDetails(
+      new UploadError("UNAUTHORIZED", "Sign in to upload")
+    );
+
+    expect(problem.error).toBe("Sign in to upload");
+    expect(problem.detail).toBe("Sign in to upload");
+  });
+
+  it("redacts the legacy field on 5xx, exactly like detail", () => {
+    const problem = toProblemDetails(
+      new UploadError("INTERNAL_ERROR", "db-prod-7 refused")
+    );
+
+    expect(problem.error).toBe("Internal error");
+    expect(JSON.stringify(problem)).not.toContain("db-prod-7");
+  });
+});

--- a/packages/pushduck/src/core/errors/from-pushduck-error.ts
+++ b/packages/pushduck/src/core/errors/from-pushduck-error.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Bridges the pre-existing `PushduckError` into `UploadError`.
+ *
+ * `core/types/errors.ts` already defines `PushduckError` with 19 infrastructure
+ * codes, and `core/storage/client.ts` throws it from 7 places. Those throws are
+ * correct and stay — this module translates them at the request boundary so the
+ * HTTP layer speaks one vocabulary.
+ *
+ * Keeping the two sets separate is deliberate. `PushduckErrorCode` describes
+ * *what went wrong inside the library* (`S3_BUCKET_NOT_FOUND`,
+ * `PROVIDER_CONFIG_INVALID`); `UploadErrorCode` describes *what the caller
+ * should be told* (`STORAGE_UNAVAILABLE`, `CONFIG_INVALID`). Several internal
+ * codes intentionally collapse to one external code, because the caller cannot
+ * act on the difference.
+ */
+
+import {
+  isPushduckError,
+  type PushduckErrorCode,
+} from "../types/errors";
+import { toUploadError, UploadError, type UploadErrorCode } from "./upload-error";
+
+/**
+ * Internal code → the code the caller is told.
+ *
+ * Where several internal failures are indistinguishable to a caller, they map
+ * to the same external code on purpose: an invalid bucket name and a missing
+ * bucket are both "storage is not usable right now" from outside.
+ */
+const CODE_MAP: Record<PushduckErrorCode, UploadErrorCode> = {
+  // Our configuration is wrong — not retryable, not the caller's fault.
+  CONFIG_INVALID: "CONFIG_INVALID",
+  CONFIG_MISSING: "CONFIG_INVALID",
+  PROVIDER_UNSUPPORTED: "CONFIG_INVALID",
+  PROVIDER_CONFIG_INVALID: "CONFIG_INVALID",
+
+  // Storage rejected us, or is unreachable.
+  S3_CONNECTION_FAILED: "STORAGE_UNAVAILABLE",
+  S3_BUCKET_NOT_FOUND: "STORAGE_UNAVAILABLE",
+  S3_ACCESS_DENIED: "STORAGE_ACCESS_DENIED",
+  S3_INVALID_CREDENTIALS: "STORAGE_ACCESS_DENIED",
+
+  // The request or its files are the problem.
+  FILE_NOT_FOUND: "NOT_FOUND",
+  FILE_TOO_LARGE: "FILE_TOO_LARGE",
+  FILE_TYPE_NOT_ALLOWED: "FILE_TYPE_NOT_ALLOWED",
+  FILE_VALIDATION_FAILED: "VALIDATION_FAILED",
+
+  // Transfer-level failures.
+  UPLOAD_FAILED: "STORAGE_UNAVAILABLE",
+  DOWNLOAD_FAILED: "STORAGE_UNAVAILABLE",
+  PRESIGNED_URL_FAILED: "STORAGE_UNAVAILABLE",
+  NETWORK_ERROR: "NETWORK_ERROR",
+  TIMEOUT_ERROR: "TIMEOUT",
+
+  UNKNOWN_ERROR: "INTERNAL_ERROR",
+};
+
+/**
+ * Normalises anything thrown on the server into an {@link UploadError}.
+ *
+ * Handles three cases:
+ * 1. Already an `UploadError` — returned unchanged.
+ * 2. A `PushduckError` from storage or config — translated through
+ *    {@link CODE_MAP}, keeping the original as `cause` and its context as `meta`.
+ * 3. Anything else, including a bare `throw new Error()` from user
+ *    middleware — becomes `INTERNAL_ERROR` / 500, which is the honest reading
+ *    of an unhandled exception.
+ */
+export function normalizeServerError(
+  value: unknown,
+  fallbackCode: UploadErrorCode = "INTERNAL_ERROR"
+): UploadError {
+  if (isPushduckError(value)) {
+    const code = CODE_MAP[value.code] ?? "INTERNAL_ERROR";
+
+    return new UploadError(code, value.message, {
+      cause: value,
+      // The original context is diagnostic detail; redaction still applies, so
+      // it only leaves the server for 4xx or when debug is enabled.
+      meta: { pushduckCode: value.code, ...value.context },
+    });
+  }
+
+  return toUploadError(value, fallbackCode);
+}

--- a/packages/pushduck/src/core/errors/index.ts
+++ b/packages/pushduck/src/core/errors/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Ecosystem-neutral error handling.
+ *
+ * Built on HTTP status codes (RFC 9110), Problem Details (RFC 9457), ES2022
+ * `Error.cause`, and plain TypeScript unions — nothing that belongs to a
+ * framework, and nothing with an upstream to keep up with.
+ *
+ * Shared by the server handler and the client engine, so one error vocabulary
+ * spans the whole library and the wire between its halves.
+ */
+
+export {
+  errorTypeUri,
+  isRequestScoped,
+  isUploadError,
+  toUploadError,
+  UPLOAD_ERROR_CODES,
+  UploadError,
+} from "./upload-error";
+export type { UploadErrorCode, UploadErrorOptions } from "./upload-error";
+
+export {
+  codeForStatus,
+  fromProblemDetails,
+  PROBLEM_JSON_MEDIA_TYPE,
+  toProblemDetails,
+  toProblemResponse,
+} from "./problem-details";
+export type { ProblemDetails, ProblemDetailsOptions } from "./problem-details";

--- a/packages/pushduck/src/core/errors/problem-details.ts
+++ b/packages/pushduck/src/core/errors/problem-details.ts
@@ -1,0 +1,240 @@
+/**
+ * @fileoverview RFC 9457 Problem Details — the wire format for errors.
+ *
+ * [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) is the IETF standard for
+ * HTTP error response bodies (July 2023; obsoletes RFC 7807). Using it instead
+ * of an invented shape means:
+ *
+ * - Go, Python, Rust, and Java clients already have libraries for it, which
+ *   matters directly for non-TypeScript server implementations.
+ * - Extension members are explicitly permitted, so `code`, `retryable`, and
+ *   `meta` are conforming rather than a fork of the standard.
+ * - It is finished. There is no upstream to keep up with.
+ *
+ * This module is pure and framework-free: it is imported by the server handler
+ * *and* by the client engine, so both sides speak one format described in one
+ * place.
+ *
+ * @example The wire shape
+ * ```jsonc
+ * {
+ *   "type": "https://pushduck.org/errors/file-too-large",
+ *   "title": "File exceeds the maximum size",
+ *   "status": 413,
+ *   "detail": "photo.jpg is 9.0 MB; the limit is 5.0 MB",
+ *   "instance": "/api/upload?route=imageUpload",
+ *   "code": "FILE_TOO_LARGE",
+ *   "retryable": false,
+ *   "meta": { "limit": 5242880, "actual": 9437184 }
+ * }
+ * ```
+ */
+
+import {
+  UploadError,
+  type UploadErrorCode,
+  UPLOAD_ERROR_CODES,
+} from "./upload-error";
+
+/** The media type RFC 9457 defines for these documents. */
+export const PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
+
+/**
+ * An RFC 9457 problem document.
+ *
+ * The first five members are the standard's; the rest are extension members,
+ * which the standard permits and which carry pushduck's semantics.
+ */
+export interface ProblemDetails {
+  /** URI identifying the problem *type*. Stable; doubles as documentation. */
+  type: string;
+  /** Short human summary of the type. Stable across occurrences. */
+  title: string;
+  /** HTTP status generated for this occurrence. */
+  status: number;
+  /** Human explanation specific to *this* occurrence. */
+  detail?: string;
+  /** URI reference identifying the specific occurrence. */
+  instance?: string;
+
+  // ---- extension members ----
+  /** Machine-readable code. Branch on this, not on `title` or `detail`. */
+  code: UploadErrorCode;
+  /** Whether retrying the identical request could plausibly succeed. */
+  retryable: boolean;
+  /** Structured context for this occurrence. */
+  meta?: Record<string, unknown>;
+
+  /**
+   * The pre-RFC-9457 message field, for clients older than this release.
+   *
+   * pushduck ≤0.6 read `body.error` and fell back to
+   * `Server error: <statusText>` when absent — so a server upgraded ahead of
+   * its clients (the usual deployment order) would silently replace every
+   * message with "Server error: Unauthorized". Emitting both keeps those
+   * clients working.
+   *
+   * @deprecated Read `detail` and `code` instead. Removed in the next major.
+   */
+  error?: string;
+}
+
+/** Options controlling how much detail leaves the server. */
+export interface ProblemDetailsOptions {
+  /**
+   * Include `detail` and `meta` for server-side failures.
+   *
+   * Off by default. A 5xx may describe our internals — bucket names, upstream
+   * messages, stack context — none of which the caller needs. 4xx detail is
+   * always included: it describes input the caller already has.
+   */
+  debug?: boolean;
+}
+
+/**
+ * Serialises an {@link UploadError} to a problem document.
+ *
+ * Redaction is driven by status class rather than configuration, so the safe
+ * behaviour is the default and requires no setup:
+ *
+ * - **4xx** — the caller's own request; `detail` and `meta` pass through.
+ * - **5xx** — ours or upstream's; `detail` is replaced with the generic title
+ *   and `meta` is dropped, unless `debug` is enabled.
+ */
+export function toProblemDetails(
+  error: UploadError,
+  options: ProblemDetailsOptions = {}
+): ProblemDetails {
+  const exposeDetail = error.isClientError || options.debug === true;
+
+  return {
+    type: error.type,
+    title: error.title,
+    status: error.status,
+    detail: exposeDetail ? error.message : error.title,
+    ...(error.instance ? { instance: error.instance } : {}),
+    code: error.code,
+    retryable: error.retryable,
+    ...(exposeDetail && error.meta ? { meta: error.meta } : {}),
+    // Mirrors `detail` for pre-0.7 clients. See the field's doc comment.
+    error: exposeDetail ? error.message : error.title,
+  };
+}
+
+/**
+ * Reconstructs an {@link UploadError} from a problem document.
+ *
+ * Tolerant by design: a proxy, a CDN error page, or an older server may return
+ * something that is not a valid problem document, and the client must still
+ * produce a usable error rather than throwing while handling an error.
+ *
+ * @param body - Parsed response body, of unknown shape
+ * @param status - HTTP status observed, used when the body omits or lies
+ */
+export function fromProblemDetails(
+  body: unknown,
+  status?: number
+): UploadError {
+  // `error` is widened here beyond the ProblemDetails declaration: very old
+  // responses used a bare string, and some deployments wrap it in an object.
+  const problem = (body ?? {}) as LegacyAwareProblem;
+
+  const code = resolveCode(problem, status);
+  const definition = UPLOAD_ERROR_CODES[code];
+
+  const message =
+    problem.detail ??
+    (typeof problem.error === "string" ? problem.error : undefined) ??
+    (typeof problem.error === "object" ? problem.error?.message : undefined) ??
+    problem.title ??
+    definition.title;
+
+  return new UploadError(code, message, {
+    status: problem.status ?? status ?? definition.status,
+    retryable: problem.retryable ?? definition.retryable,
+    meta: problem.meta,
+    instance: problem.instance,
+  });
+}
+
+/**
+ * A response that may be a problem document, a pre-0.7 pushduck body, or
+ * neither — an nginx page, a CDN error, a proxy's own JSON.
+ */
+type LegacyAwareProblem = Omit<Partial<ProblemDetails>, "error"> & {
+  error?: string | { code?: string; message?: string };
+};
+
+/**
+ * Determines the code from a response, in order of trustworthiness.
+ *
+ * 1. An explicit, recognised `code` extension member.
+ * 2. The HTTP status, which every intermediary sets correctly.
+ * 3. `INTERNAL_ERROR`.
+ */
+function resolveCode(
+  problem: LegacyAwareProblem,
+  status?: number
+): UploadErrorCode {
+  const declared =
+    problem.code ??
+    (typeof problem.error === "object" ? problem.error?.code : undefined);
+
+  if (declared && declared in UPLOAD_ERROR_CODES) {
+    return declared as UploadErrorCode;
+  }
+
+  return codeForStatus(problem.status ?? status);
+}
+
+/**
+ * Best-effort code for a bare HTTP status.
+ *
+ * Used when a response carries no pushduck code at all — an nginx 502, a
+ * CDN 504, or a server predating the error envelope.
+ */
+export function codeForStatus(status: number | undefined): UploadErrorCode {
+  switch (status) {
+    case 400:
+      return "BAD_REQUEST";
+    case 401:
+      return "UNAUTHORIZED";
+    case 403:
+      return "FORBIDDEN";
+    case 404:
+      return "NOT_FOUND";
+    case 413:
+      return "PAYLOAD_TOO_LARGE";
+    case 415:
+      return "FILE_TYPE_NOT_ALLOWED";
+    case 429:
+      return "RATE_LIMITED";
+    case 502:
+    case 503:
+      return "STORAGE_UNAVAILABLE";
+    case 504:
+      return "TIMEOUT";
+    default:
+      return status !== undefined && status >= 400 && status < 500
+        ? "BAD_REQUEST"
+        : "INTERNAL_ERROR";
+  }
+}
+
+/**
+ * Builds the HTTP `Response` for an error.
+ *
+ * Sets the RFC 9457 media type so intermediaries and clients can recognise the
+ * body without guessing.
+ */
+export function toProblemResponse(
+  error: UploadError,
+  options: ProblemDetailsOptions = {}
+): Response {
+  const problem = toProblemDetails(error, options);
+
+  return new Response(JSON.stringify(problem), {
+    status: problem.status,
+    headers: { "Content-Type": PROBLEM_JSON_MEDIA_TYPE },
+  });
+}

--- a/packages/pushduck/src/core/errors/upload-error.ts
+++ b/packages/pushduck/src/core/errors/upload-error.ts
@@ -1,0 +1,340 @@
+/**
+ * @fileoverview The error type shared by the server, the wire, and the client.
+ *
+ * ## Why this exists and what it is built on
+ *
+ * Errors are the one place a library is most tempted to adopt a framework's
+ * conventions — a `TRPCError` shape, an Effect error channel, a `Result` type.
+ * All of those move, and adopting one makes every consumer of the *other*
+ * frameworks a second-class citizen.
+ *
+ * So this is built only on things that predate the current framework landscape
+ * and will outlive it:
+ *
+ * - **RFC 9110 status codes** — universally understood by proxies, logs, and
+ *   every HTTP client in every language.
+ * - **RFC 9457 Problem Details** — the IETF standard for HTTP error bodies,
+ *   with a defined extension mechanism. Libraries exist for it in Go, Python,
+ *   Rust and Java, which matters directly for non-TypeScript ports.
+ * - **ES2022 `Error` with `cause`** — the language's own error chaining.
+ * - **Plain TypeScript string-literal unions** — narrowing is a language
+ *   feature, not a dependency.
+ *
+ * Throwing (rather than returning a `Result`) is deliberate: rejection is the
+ * platform idiom — `fetch` rejects, `await` throws. Consumers who prefer errors
+ * as values can `.catch()` in one line; consumers of an effect system can lift
+ * a rejection into their own error channel in one line. Neither direction is
+ * privileged.
+ *
+ * @example Throwing from upload middleware
+ * ```typescript
+ * .middleware(async ({ req }) => {
+ *   const user = await auth(req);
+ *   if (!user) throw new UploadError("UNAUTHORIZED", "Sign in to upload");
+ *   return { userId: user.id };
+ * })
+ * ```
+ *
+ * @example Handling on the client
+ * ```typescript
+ * try {
+ *   await uploadFiles({ files, route: "imageUpload" });
+ * } catch (error) {
+ *   if (error instanceof UploadError && error.code === "FILE_TOO_LARGE") {
+ *     alert(`Maximum size is ${error.meta?.limit} bytes`);
+ *   }
+ * }
+ * ```
+ */
+
+/**
+ * The stable, versioned vocabulary of upload failures.
+ *
+ * These are **pushduck's own** codes, deliberately not a mirror of any
+ * framework's enum. Consumers map them to whatever their ecosystem wants; that
+ * mapping lives in their code, so a rename upstream never breaks this library.
+ *
+ * Grouped by who is at fault, because that determines the status class, whether
+ * a retry is meaningful, and whether the detail is safe to expose.
+ */
+export type UploadErrorCode =
+  // ---- Caller's request is wrong: 4xx, not retryable ----
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "BAD_REQUEST"
+  | "VALIDATION_FAILED"
+  | "FILE_TOO_LARGE"
+  | "FILE_TYPE_NOT_ALLOWED"
+  | "TOO_MANY_FILES"
+  | "PAYLOAD_TOO_LARGE"
+  // ---- Caller is being throttled: 429, retryable later ----
+  | "RATE_LIMITED"
+  | "QUOTA_EXCEEDED"
+  // ---- Something upstream failed: 5xx, retryable ----
+  | "STORAGE_UNAVAILABLE"
+  | "STORAGE_ACCESS_DENIED"
+  | "NETWORK_ERROR"
+  | "TIMEOUT"
+  // ---- Our fault: 5xx, not retryable without a fix ----
+  | "CONFIG_INVALID"
+  | "INTERNAL_ERROR"
+  // ---- Client-side only ----
+  | "UPLOAD_CANCELLED";
+
+/** Static facts about a code: how it maps to HTTP and whether retrying helps. */
+interface CodeDefinition {
+  /** RFC 9110 status this code maps to. */
+  status: number;
+  /** Short, stable, human-readable summary. Same for every occurrence. */
+  title: string;
+  /**
+   * Whether retrying the identical request could plausibly succeed.
+   *
+   * Consumed directly by retry policies — TanStack Query's `retry`, a
+   * `Schedule`, or a hand-rolled backoff — none of which can infer this from a
+   * message string.
+   */
+  retryable: boolean;
+}
+
+/**
+ * The single source of truth mapping each code to its HTTP and retry semantics.
+ *
+ * Exported so a non-TypeScript implementation can be generated from it, and so
+ * the documentation cannot drift from the code.
+ */
+export const UPLOAD_ERROR_CODES: Readonly<
+  Record<UploadErrorCode, CodeDefinition>
+> = Object.freeze({
+  UNAUTHORIZED: {
+    status: 401,
+    title: "Authentication required",
+    retryable: false,
+  },
+  FORBIDDEN: { status: 403, title: "Not allowed", retryable: false },
+  NOT_FOUND: { status: 404, title: "Not found", retryable: false },
+  BAD_REQUEST: { status: 400, title: "Malformed request", retryable: false },
+  VALIDATION_FAILED: {
+    status: 400,
+    title: "File failed validation",
+    retryable: false,
+  },
+  FILE_TOO_LARGE: {
+    status: 413,
+    title: "File exceeds the maximum size",
+    retryable: false,
+  },
+  FILE_TYPE_NOT_ALLOWED: {
+    status: 415,
+    title: "File type is not allowed",
+    retryable: false,
+  },
+  TOO_MANY_FILES: {
+    status: 400,
+    title: "Too many files in one request",
+    retryable: false,
+  },
+  PAYLOAD_TOO_LARGE: {
+    status: 413,
+    title: "Request body is too large",
+    retryable: false,
+  },
+
+  RATE_LIMITED: { status: 429, title: "Rate limit exceeded", retryable: true },
+  QUOTA_EXCEEDED: { status: 429, title: "Quota exceeded", retryable: true },
+
+  STORAGE_UNAVAILABLE: {
+    status: 502,
+    title: "Storage provider unavailable",
+    retryable: true,
+  },
+  STORAGE_ACCESS_DENIED: {
+    // 502 rather than 403: the *caller* is authorised; our credentials are not.
+    // Reporting 403 would wrongly tell the client to re-authenticate.
+    status: 502,
+    title: "Storage rejected our credentials",
+    retryable: false,
+  },
+  NETWORK_ERROR: { status: 502, title: "Network failure", retryable: true },
+  TIMEOUT: { status: 504, title: "Operation timed out", retryable: true },
+
+  CONFIG_INVALID: {
+    status: 500,
+    title: "Upload is misconfigured",
+    retryable: false,
+  },
+  INTERNAL_ERROR: { status: 500, title: "Internal error", retryable: false },
+
+  UPLOAD_CANCELLED: { status: 499, title: "Upload cancelled", retryable: false },
+});
+
+/** Base URI for the `type` member of a problem document. */
+const ERROR_TYPE_BASE = "https://pushduck.org/errors/";
+
+/** Converts `FILE_TOO_LARGE` to the documentation URI `…/file-too-large`. */
+export function errorTypeUri(code: UploadErrorCode): string {
+  return ERROR_TYPE_BASE + code.toLowerCase().replace(/_/g, "-");
+}
+
+/** Options accepted by the {@link UploadError} constructor. */
+export interface UploadErrorOptions extends ErrorOptions {
+  /**
+   * Structured, machine-readable context for this occurrence.
+   *
+   * Deliberately `Record<string, unknown>` rather than a schema type — the
+   * error path must not depend on a validation library.
+   */
+  meta?: Record<string, unknown>;
+  /** Override the status implied by the code. Rarely needed. */
+  status?: number;
+  /** Override retryability. Rarely needed. */
+  retryable?: boolean;
+  /** The request path this failure relates to, for the `instance` member. */
+  instance?: string;
+}
+
+/**
+ * A pushduck upload failure.
+ *
+ * The same class is thrown on the server, serialised to RFC 9457 on the wire,
+ * and reconstructed on the client — so `code`, `status`, `retryable`, and
+ * `meta` survive the network hop rather than collapsing to a string.
+ */
+export class UploadError extends Error {
+  /**
+   * Declared as `string` rather than a literal so subclasses such as
+   * `UploadBatchError` can set their own name. `isUploadError` checks the
+   * runtime value, not the type.
+   */
+  override readonly name: string = "UploadError";
+
+  /** Stable machine-readable code. Branch on this, never on `message`. */
+  readonly code: UploadErrorCode;
+
+  /** RFC 9110 status this failure maps to. */
+  readonly status: number;
+
+  /** Whether retrying the identical request could plausibly succeed. */
+  readonly retryable: boolean;
+
+  /** Structured context for this occurrence. */
+  readonly meta?: Record<string, unknown>;
+
+  /** The request this failure relates to, when known. */
+  readonly instance?: string;
+
+  constructor(
+    code: UploadErrorCode,
+    message?: string,
+    options: UploadErrorOptions = {}
+  ) {
+    const definition = UPLOAD_ERROR_CODES[code] ?? UPLOAD_ERROR_CODES.INTERNAL_ERROR;
+
+    // `cause` is passed through to the ES2022 Error constructor, preserving the
+    // underlying failure rather than flattening it into a string.
+    super(message ?? definition.title, { cause: options.cause });
+
+    this.code = code;
+    this.status = options.status ?? definition.status;
+    this.retryable = options.retryable ?? definition.retryable;
+    this.meta = options.meta;
+    this.instance = options.instance;
+
+    // Keeps the constructor frame out of the stack in V8.
+    if (Error.captureStackTrace) Error.captureStackTrace(this, UploadError);
+  }
+
+  /** Short, stable summary for this code. Identical for every occurrence. */
+  get title(): string {
+    return (
+      UPLOAD_ERROR_CODES[this.code] ?? UPLOAD_ERROR_CODES.INTERNAL_ERROR
+    ).title;
+  }
+
+  /** Documentation URI identifying this error class. */
+  get type(): string {
+    return errorTypeUri(this.code);
+  }
+
+  /**
+   * True when the failure is attributable to the caller's request.
+   *
+   * Drives redaction: a 4xx describes input the caller already has, so its
+   * detail is safe to return; a 5xx may describe our internals.
+   */
+  get isClientError(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+/**
+ * Codes that describe the *request*, not one file within it.
+ *
+ * A batch presign runs validation per file, so one rejected file must not fail
+ * the other nine — those failures are reported per file with a 200. But a
+ * failure that applies to the whole request (the caller is not signed in, the
+ * account is over quota, our credentials are wrong) is not a property of any
+ * one file: reporting it N times inside a 200 would hide it from every status
+ * check, proxy, retry policy, and alert.
+ *
+ * These abort the batch and surface as the appropriate HTTP status.
+ */
+const REQUEST_SCOPED: ReadonlySet<UploadErrorCode> = new Set([
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "RATE_LIMITED",
+  "QUOTA_EXCEEDED",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+  "PAYLOAD_TOO_LARGE",
+  "CONFIG_INVALID",
+  "STORAGE_ACCESS_DENIED",
+  "INTERNAL_ERROR",
+]);
+
+/**
+ * Whether a failure applies to the whole request rather than a single file.
+ *
+ * @see {@link REQUEST_SCOPED}
+ */
+export function isRequestScoped(code: UploadErrorCode): boolean {
+  return REQUEST_SCOPED.has(code);
+}
+
+/**
+ * Type guard for {@link UploadError}.
+ *
+ * Prefer this over `instanceof` at module boundaries: duplicate copies of the
+ * package, or a value that crossed a realm, break `instanceof` while this
+ * structural check still holds.
+ */
+export function isUploadError(value: unknown): value is UploadError {
+  return (
+    value instanceof Error &&
+    // Checks shape rather than the `name` label, because subclasses such as
+    // UploadBatchError set their own name.
+    typeof (value as UploadError).code === "string" &&
+    typeof (value as UploadError).status === "number"
+  );
+}
+
+/**
+ * Coerces any thrown value into an {@link UploadError}.
+ *
+ * A bare `throw new Error("…")` from user middleware becomes `INTERNAL_ERROR`
+ * with a 500 — the honest reading of an unhandled exception — while the
+ * original is preserved as `cause`.
+ */
+export function toUploadError(
+  value: unknown,
+  fallbackCode: UploadErrorCode = "INTERNAL_ERROR"
+): UploadError {
+  if (isUploadError(value)) return value;
+
+  if (value instanceof Error) {
+    return new UploadError(fallbackCode, value.message, { cause: value });
+  }
+
+  return new UploadError(fallbackCode, String(value), { cause: value });
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,13 +4,32 @@
   "compilerOptions": {
     "baseUrl": ".",
     "moduleResolution": "bundler",
-    "target": "es2018",
+    "target": "es2022",
     "paths": {
-      "@/*": ["./*"],
-      "pushduck": ["../pushduck/src/index.ts"],
-      "pushduck/client": ["../pushduck/src/client.ts"]
-    }
+      "@/*": [
+        "./*"
+      ],
+      "pushduck": [
+        "../pushduck/src/index.ts"
+      ],
+      "pushduck/client": [
+        "../pushduck/src/client.ts"
+      ]
+    },
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ]
   },
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", ".turbo", "public"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    ".turbo",
+    "public",
+    "vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
## What does this PR do?

<!-- A clear description of the change. Link related issues with "Closes #123". -->

## How was it tested?

<!-- Describe how you verified the change works. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized upload error handling with stable error codes, retryability indicators, status details, and metadata.
  * Added RFC 9457 Problem Details responses using the `application/problem+json` format.
  * Added compatibility support for legacy error response formats.
  * Added conversion between existing server errors and standardized upload errors.
* **Refactor**
  * Updated the UI build target to ES2022 for improved platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->