### PR TITLE
feat(python): named lifecycle channels, and a key the library owns

### DIFF
--- a/docs/content/docs/integrations/python.mdx
+++ b/docs/content/docs/integrations/python.mdx
@@ -22,9 +22,12 @@ protocol is JSON over HTTP, so nothing is dragged into your application.
 
 ## Defining routes
 
+A route is a value. Every field is a point where your application participates,
+and every one is optional.
+
 ```python title="upload.py"
 import os
-from pushduck import Router, UploadConfig, image, file
+from pushduck import Router, Route, UploadConfig, image, file
 
 config = UploadConfig(
     bucket=os.environ["AWS_S3_BUCKET"],
@@ -36,20 +39,97 @@ config = UploadConfig(
 
 router = Router(config)
 
-@router.route("imageUpload", image(max_size="5MB"))
-async def image_upload(request):
-    user = await authenticate(request)
-    return {"user_id": user.id}          # becomes the upload's metadata
+router.add("imageUpload", Route(
+    schema=image(max_size="5MB"),
+    authorize=[require_session],                       # raise to reject
+    principal=load_user,                               # becomes ctx.user
+    key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",  # a fragment, not the key
+    metadata=lambda ctx, f: {"user_id": ctx.user.id},  # the upload's metadata
+    on_complete=[record_upload],
+))
 
-@router.route("documentUpload", file(max_size="50MB", allow_types=["application/pdf"]))
-def document_upload(request):            # sync handlers work too
-    return {"tenant": current_tenant()}
+router.add("documentUpload", Route(
+    schema=file(max_size="50MB", allow_types=["application/pdf"]),
+    metadata=lambda ctx, f: {"tenant": current_tenant()},   # sync is fine too
+))
 ```
 
-The decorated function **is** the middleware. Raise to reject the request;
-whatever you return becomes the upload's metadata. There is no separate
-middleware concept because a decorated handler already runs on every request —
-that is what a Python developer expects.
+### The channels
+
+| Channel | Runs | What it does |
+| --- | --- | --- |
+| `authorize` | once per request | Raise to reject the request. The return value is **ignored**. |
+| `principal` | once per request | Its return value **is** `ctx.user`. |
+| `around` | once per request | `async def f(ctx): ... yield ...` — wraps everything below. |
+| `validate` | per file | Raise to fail **that file**; the rest of the batch continues. |
+| `key` | per file | Returns a key *fragment*. pushduck sanitises it. |
+| `metadata` | per file | Its return value **is** the upload's metadata. |
+| `on_complete` | per file | After an upload is confirmed. |
+| `on_error` | on failure | Observational. |
+
+Channels that produce a value take one callable. Channels that veto, wrap or
+observe take a list, applied in order. Sync and async are both accepted
+everywhere, resolved once when the route is registered.
+
+Each value-producing channel is named after the value it produces. That is why
+"authenticate, but publish no metadata" has an obvious spelling — a route with
+`authorize` and no `metadata` — rather than being something you have to
+express by returning nothing.
+
+<Callout type="warn">
+  **`ctx.metadata` starts empty, and the client's payload is never merged into
+  it.** What the caller sent is available as `ctx.client_metadata`, under a name
+  that reads as a warning. A route with no `metadata` channel publishes `{}`.
+  To forward what the client sent, say so:
+  `metadata=lambda ctx, f: dict(ctx.client_metadata)`.
+</Callout>
+
+### Keys are sanitised, always
+
+The `key` channel returns a fragment. pushduck rejects `..` segments, absolute
+paths and URL delimiters, then re-sanitises every segment before signing:
+
+```python
+key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}"
+# "acme/写真 photo.png"  ->  "acme/写真_photo.png"
+# "../../etc/passwd"    ->  CONFIG_INVALID, refused
+```
+
+This is deliberate and not adjustable. A key hook that is trusted verbatim is
+how CVE-2024-39330 (Django) and CVE-2026-34750 (Payload CMS) happened; both
+were fixed by moving the check somewhere an override cannot reach.
+
+### Sharing behaviour between routes
+
+A route is a plain dataclass, so `dataclasses.replace` derives one from another
+and stays correct when a channel is added later:
+
+```python
+from dataclasses import replace
+
+tenant = Route(authorize=[require_session], principal=load_user, key=tenant_key)
+
+router.add("avatar",   replace(tenant, schema=image(max_size="5MB")))
+router.add("document", replace(tenant, schema=file(max_size="50MB")))
+```
+
+For behaviour every route shares, give the router defaults. They **prepend** to
+each route's own channels rather than replacing them:
+
+```python
+router = Router(config, defaults=Route(authorize=[require_session]))
+```
+
+### Seeing what is registered
+
+```python
+print(router.describe())
+#   avatar    authorize(1) principal key metadata on_complete(1)
+#   public    schema only
+```
+
+Worth printing at boot. A route that has quietly lost its authentication is
+otherwise invisible until someone notices the uploads.
 
 <Callout type="warn">
   Raise `UploadError` to control the status. Any other exception becomes a 500

--- a/packages/pushduck-py/cmd/conformance_server.py
+++ b/packages/pushduck-py/cmd/conformance_server.py
@@ -18,7 +18,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from pushduck import Request, Router, UploadConfig, UploadError, file, image  # noqa: E402
+from pushduck import (  # noqa: E402
+    Request,
+    Route,
+    Router,
+    UploadConfig,
+    UploadError,
+    file,
+    image,
+)
 from pushduck.router import parse_query  # noqa: E402
 
 PORT = int(os.environ.get("PORT", "4322"))
@@ -32,30 +40,38 @@ config = UploadConfig(
 
 router = Router(config)
 
+
+def require_conformance_token(request: Request) -> None:
+    if request.header("authorization") != "Bearer conformance-token":
+        raise UploadError("UNAUTHORIZED", "Sign in to upload")
+
+
 # Exactly the route surface `conformance/README.md` requires, so a failure means
 # the implementation disagrees with the protocol rather than that the servers
 # were configured differently.
-router.add_route("imageUpload", image(max_size="5MB"))
-router.add_route("fileUpload", file(max_size="50MB"))
+router.add("imageUpload", Route(schema=image(max_size="5MB")))
+router.add("fileUpload", Route(schema=file(max_size="50MB")))
 
+router.add(
+    "privateUpload",
+    Route(
+        schema=file(max_size="5MB"),
+        authorize=[require_conformance_token],
+        metadata=lambda ctx, f: {"userId": "conformance-user"},
+    ),
+)
 
-@router.route("privateUpload", file(max_size="5MB"))
-def private_upload(request: Request) -> dict:
-    if request.header("authorization") != "Bearer conformance-token":
-        raise UploadError("UNAUTHORIZED", "Sign in to upload")
-    return {"userId": "conformance-user"}
-
-
-@router.route("strictUpload", file(max_size="5MB"))
-def strict_upload(request: Request) -> None:
-    """Authenticates and returns nothing.
-
-    The shape that reveals whether an implementation treats "no metadata" as
-    "keep whatever the client sent".
-    """
-    if request.header("authorization") != "Bearer conformance-token":
-        raise UploadError("UNAUTHORIZED", "Sign in to upload")
-    return None
+# Authenticates and publishes nothing — the shape that reveals whether an
+# implementation treats "no metadata" as "keep whatever the client sent".
+#
+# Under the channel design this is simply a route with `authorize` and no
+# `metadata`. There is no longer any way to spell it that could be misread,
+# which is the whole point: the previous spelling was `return None` from a
+# handler whose return value was also the metadata.
+router.add(
+    "strictUpload",
+    Route(schema=file(max_size="5MB"), authorize=[require_conformance_token]),
+)
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/packages/pushduck-py/pushduck/__init__.py
+++ b/packages/pushduck-py/pushduck/__init__.py
@@ -10,7 +10,7 @@ from .config import (
     MAX_PARTS,
     MIN_PART_SIZE,
     FileMeta,
-    Route,
+    Schema,
     UploadConfig,
     file,
     format_size,
@@ -18,14 +18,19 @@ from .config import (
     parse_size,
 )
 from .errors import UploadError
-from .keys import generate_key
+from .keys import generate_key, resolve_key
 from .router import PROTOCOL_VERSION, Request, Response, Router
+from .routes import Anonymous, Completion, Context, Route
 from .wsgi import wsgi_app
 
 __all__ = [
     "UploadConfig",
     "Router",
     "Route",
+    "Schema",
+    "Context",
+    "Completion",
+    "Anonymous",
     "Request",
     "Response",
     "FileMeta",
@@ -35,6 +40,7 @@ __all__ = [
     "asgi_app",
     "wsgi_app",
     "generate_key",
+    "resolve_key",
     "parse_size",
     "format_size",
     "PROTOCOL_VERSION",

--- a/packages/pushduck-py/pushduck/config.py
+++ b/packages/pushduck-py/pushduck/config.py
@@ -1,13 +1,13 @@
 """Configuration, routes and validation.
 
 The TypeScript package uses a fluent builder because TypeScript's inference
-carries types through each link of the chain. Go uses structs with functional
-options because that is what a Go developer reads without explanation.
+carries types through each link of the chain. Go and Python both use a struct
+of named, independently-optional fields, because that is the one shape in which
+a misspelled channel fails loudly in both languages.
 
-Python's equivalent is dataclasses and decorators. A route is declared with
-``@router.route(...)`` and its middleware *is* the decorated function — there is
-no separate middleware concept to learn, because a Python developer already
-expects a decorated handler to run on every request.
+This module holds the parts that are not lifecycle: credentials, the file
+descriptor a client sends, and the size/type schema. The channels live in
+``routes.py``.
 """
 
 from __future__ import annotations
@@ -119,24 +119,20 @@ def format_size(size: int) -> str:
 
 
 @dataclass
-class Route:
-    """One named upload endpoint."""
+class Schema:
+    """Size and type constraints for a route.
+
+    Separate from :class:`~pushduck.routes.Route` because the two answer
+    different questions. A schema says what a file may be; a route says who may
+    upload it and what happens around it. Keeping them one object was what made
+    `image(...)` and "the thing holding your auth handler" the same type.
+    """
 
     max_size: Optional[int] = None
     allow_types: Sequence[str] = ()
-    #: The decorated function. Runs on every operation for this route and may
-    #: raise to reject; whatever it returns becomes the upload's metadata.
-    handler: Optional[Callable[..., object]] = None
-    #: Whether the handler takes ``(request, file)`` rather than ``(request)``.
-    #: Resolved once at registration, so an unsupported signature fails at
-    #: import time rather than on a user's first upload.
-    handler_wants_file: bool = False
-    #: Reject a completion presenting no token. Off by default so clients older
-    #: than the token keep working.
-    require_completion_token: bool = False
 
-    def validate(self, file: FileMeta) -> Optional[str]:
-        """Return a message when the file violates this route's constraints.
+    def check(self, file: FileMeta) -> Optional[str]:
+        """Return a message when the file violates this schema.
 
         A message rather than an exception, because a constraint violation is a
         *per-file* outcome reported inside a 200 — not a request failure. It is
@@ -162,21 +158,19 @@ class Route:
         return f"File type {file.type} is not allowed"
 
 
-def image(max_size: "str | int | None" = None, **kwargs: object) -> Route:
-    """A route restricted to images."""
-    return file(max_size=max_size, allow_types=("image/*",), **kwargs)  # type: ignore[arg-type]
+def image(max_size: "str | int | None" = None) -> Schema:
+    """A schema restricted to images."""
+    return file(max_size=max_size, allow_types=("image/*",))
 
 
 def file(  # noqa: A001 - reads naturally at the call site
     max_size: "str | int | None" = None,
     allow_types: Sequence[str] = (),
-    require_completion_token: bool = False,
-) -> Route:
-    """A route with no type restriction unless ``allow_types`` is given."""
-    return Route(
+) -> Schema:
+    """A schema with no type restriction unless ``allow_types`` is given."""
+    return Schema(
         max_size=parse_size(max_size) if max_size is not None else None,
         allow_types=tuple(allow_types),
-        require_completion_token=require_completion_token,
     )
 
 

--- a/packages/pushduck-py/pushduck/config.py
+++ b/packages/pushduck-py/pushduck/config.py
@@ -131,7 +131,7 @@ class Schema:
     max_size: Optional[int] = None
     allow_types: Sequence[str] = ()
 
-    def check(self, file: FileMeta) -> Optional[str]:
+    def validate(self, file: FileMeta) -> Optional[str]:
         """Return a message when the file violates this schema.
 
         A message rather than an exception, because a constraint violation is a

--- a/packages/pushduck-py/pushduck/keys.py
+++ b/packages/pushduck-py/pushduck/keys.py
@@ -82,7 +82,7 @@ def generate_key(original_name: str) -> str:
 
     name = "".join(out)
 
-    collapsed = []
+    collapsed: list[str] = []
     for char in name:
         if char == "_" and collapsed and collapsed[-1] == "_":
             continue
@@ -106,3 +106,85 @@ def generate_key(original_name: str) -> str:
         name = f"file-{_fingerprint(original_name)}"
 
     return name
+
+
+# ─── the chokepoint ──────────────────────────────────────────────────────────
+
+#: S3's hard limit. The `key` channel returns a fragment; the library is what
+#: guarantees the result is a legal key, so the check belongs here.
+MAX_TOTAL_KEY_BYTES = 1024
+
+_REJECTED_CHARS = frozenset("?#%")
+
+
+def resolve_key(fragment: str, original_name: str) -> str:
+    """Turn a ``key`` channel's return value into an object key.
+
+    The channel returns a *fragment*. This function owns the result: it refuses
+    anything that cannot be made safe, and re-sanitises every segment of what
+    is left through :func:`generate_key`.
+
+    Both halves matter. Refusing traversal is the obvious one. Re-sanitising is
+    the half that is easy to skip and expensive to skip: without it, the
+    non-Latin filename handling above applies only to the *default* key, and is
+    bypassed entirely the moment an application supplies its own — so
+    ``文档.pdf`` and ``写真.pdf`` would start colliding again for exactly the
+    users who customised their keys.
+
+    Django arrived at the same arrangement the hard way. CVE-2024-39330 was a
+    ``Storage`` subclass overriding ``generate_filename`` without replicating
+    the parent's validation; the fix moved the checks into ``Storage.save`` so
+    that no override can bypass them. Rails (CVE-2026-33173) and Uppy — which
+    renamed its old default ``unsafeGetKey`` — both relocated the guarantee
+    rather than documenting the hazard.
+
+    Raises ``CONFIG_INVALID`` rather than a 4xx: a key hook returning ``..`` is
+    a bug in the application, not a malformed request from its caller.
+    """
+    from .errors import UploadError
+
+    def reject(why: str) -> "UploadError":
+        return UploadError(
+            "CONFIG_INVALID",
+            f"the `key` channel returned {fragment!r}, which {why}. "
+            "Return a path fragment; pushduck adds the prefix and sanitises it.",
+        )
+
+    if not isinstance(fragment, str):
+        raise UploadError(
+            "CONFIG_INVALID",
+            f"the `key` channel returned {type(fragment).__name__}, expected a string",
+        )
+
+    if not fragment:
+        raise reject("is empty")
+
+    if fragment.startswith("/"):
+        # An absolute-looking key is not an error in S3 — it creates an object
+        # whose name begins with a slash, which is almost never intended and
+        # breaks every URL built by concatenation.
+        raise reject("is absolute")
+
+    for char in fragment:
+        if char in _REJECTED_CHARS:
+            raise reject(f"contains {char!r}, which changes how the key parses in a URL")
+        if _is_dangerous(char):
+            # Stripped silently by `generate_key` for a *filename*, because
+            # there the alternative is rejecting the user's upload. In a key the
+            # application chose, silently returning something other than what
+            # was asked for is the worse failure.
+            raise reject(f"contains U+{ord(char):04X}, a control or bidi character")
+
+    segments = fragment.split("/")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise reject("contains an empty, '.' or '..' segment")
+
+    # Each segment goes through the same sanitiser the default path uses, so a
+    # custom key cannot opt out of the Unicode handling above.
+    resolved = "/".join(generate_key(segment) for segment in segments)
+
+    if len(resolved.encode("utf-8")) > MAX_TOTAL_KEY_BYTES:
+        raise reject(f"exceeds S3's {MAX_TOTAL_KEY_BYTES}-byte key limit once sanitised")
+
+    return resolved

--- a/packages/pushduck-py/pushduck/router.py
+++ b/packages/pushduck-py/pushduck/router.py
@@ -12,15 +12,16 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-import inspect
+import contextlib
 import json
-from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from dataclasses import dataclass, replace as _replace
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 from urllib.parse import parse_qs, quote
 
-from .config import FileMeta, Route, UploadConfig, choose_part_size, file as file_route
+from .config import FileMeta, Schema, UploadConfig, choose_part_size
 from .errors import UploadError, as_upload_error, problem_document
-from .keys import generate_key
+from .keys import generate_key, resolve_key
+from .routes import Completion, Context, Route
 from .multipart import (
     abort_multipart_upload,
     complete_multipart_upload,
@@ -70,43 +71,107 @@ class Response:
     body: bytes
 
 
-Handler = Callable[..., Union[Optional[Dict[str, Any]], Awaitable[Optional[Dict[str, Any]]]]]
+async def _invoke(channel: Any, *args: Any) -> Any:
+    """Call a channel.
+
+    ``Route.__post_init__`` has already normalised every channel to a coroutine
+    function, so this is always awaitable — but the *declared* field types
+    describe what a user may pass in, which is either shape. This helper is
+    where those two views meet, rather than a ``cast`` at each of the eight call
+    sites.
+    """
+    return await channel(*args)
+
+
+#: Every action this server understands. Validated before the value is echoed
+#: into a response header, because ASGI encodes headers as latin-1 and an
+#: unvalidated `?action=☃` would raise inside the send path — outside any
+#: handler's reach, and therefore an unauthenticated crash rather than a
+#: problem document.
+ACTIONS = frozenset(
+    {
+        "presign",
+        "complete",
+        "multipart-init",
+        "multipart-sign",
+        "multipart-complete",
+        "multipart-abort",
+        "multipart-parts",
+    }
+)
 
 
 class Router:
     """Serves one endpoint for a set of named routes.
 
-    Routes are declared with the decorator, because a Python developer already
-    expects a decorated handler to run on every request — so there is no
-    separate middleware concept to learn:
+    A route is a value, so registering one is an ordinary function call::
 
         router = Router(config)
 
-        @router.route("imageUpload", image(max_size="5MB"))
-        async def image_upload(request):
-            user = await authenticate(request)
-            return {"user_id": user.id}
+        router.add("avatar", Route(
+            schema=image(max_size="5MB"),
+            authorize=[require_session],
+            principal=load_user,
+            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            metadata=lambda ctx, f: {"owner_id": ctx.user.id},
+            on_complete=[record_upload],
+        ))
+
+    Defaults shared by every route are given once and *prepend* to each route's
+    own channels rather than replacing them. DRF made the opposite choice —
+    a view's ``permission_classes`` replaces the global default — and the result
+    is that adding one route-specific rule silently drops the global one.
     """
 
-    def __init__(self, config: UploadConfig) -> None:
+    def __init__(self, config: UploadConfig, defaults: Optional[Route] = None) -> None:
         self.config = config
+        self.defaults = defaults
         self.routes: Dict[str, Route] = {}
 
-    def route(self, name: str, schema: Optional[Route] = None) -> Callable[[Handler], Handler]:
-        """Register a route and its handler."""
+    def add(self, name: str, route: Route) -> Route:
+        """Register a route. Returns it, so it can be reused or derived from."""
+        if not isinstance(route, Route):
+            raise TypeError(
+                f'route "{name}" is {type(route).__name__}; pass a Route. '
+                "A bare schema goes in Route(schema=...)."
+            )
+        self.routes[name] = self._apply_defaults(route)
+        return route
 
-        def decorate(handler: Handler) -> Handler:
-            definition = schema or file_route()
-            definition.handler = handler
-            definition.handler_wants_file = _wants_file(name, handler)
-            self.routes[name] = definition
-            return handler
+    def _apply_defaults(self, route: Route) -> Route:
+        """Prepend the router's shared channels to a route's own."""
+        if self.defaults is None:
+            return route
 
-        return decorate
+        merged: Dict[str, Any] = {}
+        for name in ("authorize", "around", "validate", "on_complete", "on_error"):
+            shared = getattr(self.defaults, name)
+            if shared:
+                merged[name] = tuple(shared) + tuple(getattr(route, name))
 
-    def add_route(self, name: str, schema: Route) -> None:
-        """Register a route with no handler, for the plainest possible case."""
-        self.routes[name] = schema
+        # Single-slot channels are not merged — two functions cannot both be
+        # the key — so a route's own always wins, and the default fills in only
+        # where the route is silent.
+        for name in ("principal", "key", "metadata", "schema"):
+            if getattr(route, name) is None and getattr(self.defaults, name) is not None:
+                merged[name] = getattr(self.defaults, name)
+
+        return _replace(route, **merged) if merged else route
+
+    def describe(self) -> str:
+        """Which channels each route has, for printing at boot.
+
+        A route that has silently lost its authentication is otherwise
+        invisible until someone notices the uploads. tusd added a
+        ``Capabilities()`` printout for the same reason.
+        """
+        if not self.routes:
+            return "no routes registered"
+        width = max(len(name) for name in self.routes)
+        return "\n".join(
+            f"  {name.ljust(width)}  {route.describe()}"
+            for name, route in sorted(self.routes.items())
+        )
 
     def asgi(self):
         """This router as an ASGI application.
@@ -138,18 +203,28 @@ class Router:
         # Omitting `action` means presign, or every client would have to send a
         # parameter with only one sensible value.
         action = request.query.get("action") or "presign"
+        known_action = action in ACTIONS
 
-        # Set on every response, including failures: a client reading the
-        # header to negotiate behaviour needs it most on the responses an older
-        # server is likeliest to produce.
+        # Set on every response, including failures: a client reading the header
+        # to negotiate behaviour needs it most on the responses an older server
+        # is likeliest to produce.
+        #
+        # Only values this server recognises are echoed. ASGI encodes header
+        # values as latin-1, so reflecting an arbitrary query parameter raises
+        # inside the send path — outside every handler, and therefore an
+        # unauthenticated crash rather than a problem document. `?action=☃` was
+        # enough.
         telemetry = {
             "X-Pushduck-Protocol": str(PROTOCOL_VERSION),
-            "X-Pushduck-Action": action,
+            "X-Pushduck-Action": action if known_action else "unknown",
         }
-        if route_name:
+        if route_name in self.routes:
             telemetry["X-Pushduck-Route"] = route_name
 
         try:
+            if not known_action:
+                raise UploadError("BAD_REQUEST", f"Unknown action: {action!r}")
+
             if request.method == "GET" and not route_name:
                 return self._json(200, telemetry, self._introspect())
 
@@ -175,7 +250,11 @@ class Router:
 
             raise UploadError("BAD_REQUEST", f"Unknown action: {action}")
 
-        except BaseException as error:  # noqa: BLE001 - every failure becomes a document
+        except Exception as error:  # noqa: BLE001 - every failure becomes a document
+            # `Exception`, not `BaseException`. Catching the latter swallows
+            # `asyncio.CancelledError`, so a disconnected client, a server-side
+            # timeout and a graceful shutdown all turn into a 500 the framework
+            # reads as a normal response — and the task refuses to cancel.
             typed = as_upload_error(error)
             document = problem_document(typed, request.path)
             body = json.dumps(document).encode("utf-8")
@@ -195,56 +274,124 @@ class Router:
             "features": ["multipart"],
         }
 
-    async def _run_handler(
+    # ─── lifecycle ───────────────────────────────────────────────────────────
+    #
+    #   authorize (list, per request, veto)
+    #   principal (per request, produces ctx.user)
+    #   around    (list, per request, wraps everything below)
+    #     schema  (per file, produces a message)
+    #     validate(list, per file, veto)
+    #     key     (per file, produces a fragment; the library owns the result)
+    #     metadata(per file, produces ctx.metadata)
+    #
+    # Each channel is named after what it produces, which is what makes
+    # "authenticate but publish no metadata" expressible without overloading a
+    # return value.
+
+    async def _open(
         self,
         route: Route,
         request: Request,
-        file: FileMeta,
-        client_metadata: Dict[str, Any],
-    ) -> Dict[str, Any]:
-        """Invoke the route's handler and return the upload's metadata.
+        route_name: str,
+        client_metadata: Mapping[str, Any],
+    ) -> Context[Any]:
+        """Run the per-request channels and build the context.
 
-        The contract is deliberately narrow, because the previous one was not
-        and the difference was an authorisation bug:
-
-        * **No handler** — the route is public; the client's metadata is all
-          there is.
-        * **Returns a mapping** — that mapping *is* the metadata. The client's
-          is replaced rather than merged, so a caller cannot add claims the
-          handler never made.
-        * **Returns ``None``** — the upload has no metadata.
-        * **Returns anything else** — a programming error, raised rather than
-          quietly falling back to something plausible.
-
-        Sync and async handlers are both accepted: Django and Flask users write
-        sync ones, and forcing ``async def`` on half the ecosystem would make
-        this package feel foreign in it.
+        Once per request, not once per file. The previous design ran the
+        handler inside the file loop, so a 50-file batch performed 50 session
+        lookups — an amplification primitive reachable by anyone who could
+        reach the endpoint.
         """
-        if route.handler is None:
-            # The route is public: the client's metadata is all there is. Still
-            # untrusted, and the application must treat it that way.
-            return dict(client_metadata)
+        for check in route.authorize:
+            await _invoke(check, request)
 
-        arguments = [request, file] if route.handler_wants_file else [request]
-        produced = route.handler(*arguments)
-        if inspect.isawaitable(produced):
-            produced = await produced
+        user = await _invoke(route.principal, request) if route.principal is not None else None
 
-        if produced is None:
-            # Not "keep whatever the client sent". An authenticate-only handler
-            # returning nothing is the most natural shape there is, and reading
-            # it as consent to the caller's identity claims silently promotes
-            # untrusted input to authoritative.
-            return {}
+        return Context(
+            request=request,
+            route=route_name,
+            user=user,
+            # Kept, but never merged into `metadata`. The name is the warning.
+            client_metadata=dict(client_metadata),
+            metadata={},
+        )
 
-        if not isinstance(produced, Mapping):
-            raise TypeError(
-                f"the handler returned {type(produced).__name__}; return a "
-                "mapping of metadata, or None for no metadata"
-            )
+    @contextlib.asynccontextmanager
+    async def _around(self, route: Route, ctx: Context[Any]):
+        """Enter every ``around`` generator, innermost last.
 
-        # Copied, so a handler cannot hand out a reference it keeps mutating.
-        return dict(produced)
+        The only channel that brackets rather than transforms. Django rewrote
+        its entire middleware layer (DEP 0005) because the split
+        ``process_request``/``process_response`` form could not guarantee that
+        an entered hook would be exited — which is precisely what a transaction
+        needs.
+        """
+        async with contextlib.AsyncExitStack() as stack:
+            for wrap in route.around:
+                await stack.enter_async_context(
+                    contextlib.asynccontextmanager(wrap)(ctx)
+                )
+            yield
+
+    async def _prepare(
+        self, route: Route, ctx: Context[Any], file: FileMeta
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Run the per-file channels. Returns ``(key, metadata)``.
+
+        Raising ``UploadError`` from ``validate`` fails *this file* while the
+        others continue, because the channel decides the scope — the same
+        exception raised from ``authorize`` fails the whole request. Any other
+        exception propagates: a ``TypeError`` from a bug is not a per-file
+        outcome, and turning it into one would put an internal message in the
+        response body.
+        """
+        if route.schema is not None:
+            message = route.schema.check(file)
+            if message:
+                raise UploadError("VALIDATION_FAILED", message)
+
+        for check in route.validate:
+            await _invoke(check, ctx, file)
+
+        if route.key is not None:
+            # A fragment, not a key. `resolve_key` refuses traversal and
+            # re-sanitises every segment, so a custom key cannot opt out of the
+            # handling that keeps non-Latin filenames from colliding.
+            key = resolve_key(await _invoke(route.key, ctx, file), file.name)
+        else:
+            key = generate_key(file.name)
+
+        # A per-file view, so one file's key and metadata cannot leak into the
+        # next. The request-level context stays the shared, read-mostly part.
+        scoped = _replace(ctx, key=key, metadata={})
+
+        metadata: Dict[str, Any] = {}
+        if route.metadata is not None:
+            produced = await _invoke(route.metadata, scoped, file)
+            if not isinstance(produced, Mapping):
+                raise TypeError(
+                    f"the `metadata` channel returned {type(produced).__name__}; "
+                    "return a mapping"
+                )
+            metadata = dict(produced)
+
+        return key, metadata
+
+    async def _report(
+        self,
+        route: Route,
+        ctx: Optional[Context[Any]],
+        file: Optional[FileMeta],
+        error: BaseException,
+    ) -> None:
+        """Fire ``on_error``. Observational: a failure here changes nothing."""
+        if ctx is None:
+            return
+        for observer in route.on_error:
+            try:
+                await _invoke(observer, ctx, file, error)
+            except Exception:  # noqa: BLE001 - an observer cannot change the outcome
+                pass
 
     # ─── presign ─────────────────────────────────────────────────────────────
 
@@ -256,54 +403,59 @@ class Router:
         if not isinstance(files, list):
             raise UploadError("BAD_REQUEST", "`files` must be an array of file descriptors")
 
-        client_metadata = payload.get("metadata") or {}
+        ctx = await self._open(route, request, route_name, payload.get("metadata") or {})
         results: List[Dict[str, Any]] = []
 
-        for raw in files:
-            file = FileMeta.from_json(raw)
+        async with self._around(route, ctx):
+            for raw in files:
+                file = FileMeta.from_json(raw)
 
-            # The handler authenticates the *request*, so a rejection fails all
-            # of it. A constraint violation is per-file. That distinction is the
-            # one the conformance suite exists to pin down.
-            metadata = await self._run_handler(route, request, file, dict(client_metadata))
+                try:
+                    key, metadata = await self._prepare(route, ctx, file)
+                except UploadError as error:
+                    if error.status >= 500:
+                        # The server is at fault — a key channel returning `..`,
+                        # a misconfiguration. Failing one entry of a batch would
+                        # report a bug in this deployment as a property of the
+                        # user's file.
+                        raise
+                    await self._report(route, ctx, file, error)
+                    results.append(
+                        {"success": False, "file": file.to_json(), "error": error.message}
+                    )
+                    continue
 
-            message = route.validate(file)
-            if message:
-                results.append({"success": False, "file": file.to_json(), "error": message})
-                continue
+                scheme, host, path = self.config.object_address(key)
 
-            key = generate_key(file.name)
-            scheme, host, path = self.config.object_address(key)
+                url = presign(
+                    access_key_id=self.config.access_key_id,
+                    secret_access_key=self.config.secret_access_key,
+                    session_token=self.config.session_token,
+                    method="PUT",
+                    scheme=scheme,
+                    host=host,
+                    path=path,
+                    region=self.config.region,
+                    headers={"x-amz-acl": "private"},
+                    expires_in=self.config.upload_expiry,
+                    now=self.config.now(),
+                )
 
-            url = presign(
-                access_key_id=self.config.access_key_id,
-                secret_access_key=self.config.secret_access_key,
-                session_token=self.config.session_token,
-                method="PUT",
-                scheme=scheme,
-                host=host,
-                path=path,
-                region=self.config.region,
-                headers={"x-amz-acl": "private"},
-                expires_in=self.config.upload_expiry,
-                now=self.config.now(),
-            )
+                required = {"x-amz-acl": "private"}
+                if file.type:
+                    required["Content-Type"] = file.type
 
-            required = {"x-amz-acl": "private"}
-            if file.type:
-                required["Content-Type"] = file.type
-
-            results.append(
-                {
-                    "success": True,
-                    "file": file.to_json(),
-                    "presignedUrl": url,
-                    "key": key,
-                    "requiredHeaders": required,
-                    "metadata": metadata,
-                    "completionToken": self._sign_completion(key, route_name),
-                }
-            )
+                results.append(
+                    {
+                        "success": True,
+                        "file": file.to_json(),
+                        "presignedUrl": url,
+                        "key": key,
+                        "requiredHeaders": required,
+                        "metadata": metadata,
+                        "completionToken": self._sign_completion(key, route_name),
+                    }
+                )
 
         return self._json(200, telemetry, {"success": True, "results": results})
 
@@ -317,51 +469,69 @@ class Router:
         if not isinstance(completions, list):
             raise UploadError("BAD_REQUEST", "`completions` must be an array")
 
-        # Authorised in full before any hook runs, so a batch containing one
-        # unauthorised entry cannot fire the handler for the others.
-        authorised: List[Tuple[Dict[str, Any], FileMeta, str]] = []
+        ctx = await self._open(route, request, route_name, {})
+        results = []
 
-        for entry in completions:
-            if not isinstance(entry, dict):
-                raise UploadError("BAD_REQUEST", "each completion must be an object")
+        async with self._around(route, ctx):
+            # Every entry is authorised before any `on_complete` fires, so a
+            # batch containing one unauthorised entry cannot commit the others.
+            verified: List[Tuple[str, FileMeta, Dict[str, Any]]] = []
 
-            key = str(entry.get("key", ""))
-            token = entry.get("completionToken")
+            for entry in completions:
+                if not isinstance(entry, dict):
+                    raise UploadError("BAD_REQUEST", "each completion must be an object")
 
-            if token:
-                claim = self._verify_completion(str(token))
-                if claim.get("key") != key or claim.get("route") != route_name:
+                key = str(entry.get("key", ""))
+                token = entry.get("completionToken")
+
+                if token:
+                    claim = self._verify_completion(str(token))
+                    if claim.get("key") != key or claim.get("route") != route_name:
+                        raise UploadError(
+                            "FORBIDDEN",
+                            "This completion does not match the upload it was issued for",
+                        )
+                elif route.require_completion_token:
                     raise UploadError(
                         "FORBIDDEN",
-                        "This completion does not match the upload it was issued for",
+                        "This route requires the completion token issued at presign",
                     )
-            elif route.require_completion_token:
-                raise UploadError(
-                    "FORBIDDEN",
-                    "This route requires the completion token issued at presign",
+
+                file = FileMeta.from_json(entry.get("file") or {"name": key, "size": 0})
+
+                # The metadata channel runs again rather than trusting what the
+                # client echoed back. Its input is the server's context, so the
+                # result cannot contain a claim the application never made.
+                scoped = _replace(ctx, key=key, metadata={})
+                metadata: Dict[str, Any] = {}
+                if route.metadata is not None:
+                    produced = await _invoke(route.metadata, scoped, file)
+                    metadata = dict(produced) if isinstance(produced, Mapping) else {}
+
+                verified.append((key, file, metadata))
+
+            for key, file, metadata in verified:
+                scheme, host, path = self.config.object_address(key)
+                url = f"{scheme}://{host}{path}"
+
+                for observer in route.on_complete:
+                    await _invoke(
+                        observer,
+                        _replace(ctx, key=key, metadata=metadata),
+                        Completion(key=key, file=file, url=url),
+                    )
+
+                results.append(
+                    {
+                        "success": True,
+                        "key": key,
+                        "url": url,
+                        "file": file.to_json(),
+                        "metadata": metadata,
+                    }
                 )
 
-            file = FileMeta.from_json(entry.get("file") or {"name": key, "size": 0})
-            metadata = await self._run_handler(
-                route, request, file, dict(entry.get("metadata") or {})
-            )
-            authorised.append((metadata, file, key))
-
-        results = []
-        for metadata, file, key in authorised:
-            scheme, host, path = self.config.object_address(key)
-            results.append(
-                {
-                    "success": True,
-                    "key": key,
-                    "url": f"{scheme}://{host}{path}",
-                    "file": file.to_json(),
-                    "metadata": metadata,
-                }
-            )
-
         return self._json(200, telemetry, {"success": True, "results": results})
-
 
     # ─── multipart ───────────────────────────────────────────────────────────
 
@@ -379,9 +549,9 @@ class Router:
         if session.get("route") != route_name:
             raise UploadError("FORBIDDEN", "Invalid or expired multipart session")
 
-        await self._run_handler(
-            route, request, FileMeta(str(session["key"]), int(session.get("totalSize") or 0)), {}
-        )
+        # Re-runs `authorize` and `principal`, so a revoked user cannot finish
+        # an upload they were allowed to start.
+        await self._open(route, request, route_name, {})
 
         return session
 
@@ -396,17 +566,12 @@ class Router:
                 "`file` with name, size and type is required to start a multipart upload",
             )
 
-        # Handler and validation run here exactly as they do for a single PUT,
-        # so a multipart upload cannot bypass a route's constraints.
-        metadata = await self._run_handler(
-            route, request, file, dict(payload.get("metadata") or {})
-        )
-
-        message = route.validate(file)
-        if message:
-            raise UploadError("VALIDATION_FAILED", message)
-
-        key = generate_key(file.name)
+        # The same channels run here as for a single PUT, so a multipart upload
+        # cannot bypass a route's constraints. Two of the three upload-library
+        # CVEs found while designing this were a second entry point that skipped
+        # stages the first one ran.
+        ctx = await self._open(route, request, route_name, payload.get("metadata") or {})
+        key, metadata = await self._prepare(route, ctx, file)
         upload_id = create_multipart_upload(self.config, key, file.type)
         part_size = choose_part_size(file.size, payload.get("partSize"))
 
@@ -565,43 +730,6 @@ class Router:
         headers = dict(telemetry)
         headers["Content-Type"] = "application/json"
         return Response(status, headers, json.dumps(body).encode("utf-8"))
-
-
-def _wants_file(route_name: str, handler: Handler) -> bool:
-    """Decide once whether a handler takes the file as a second argument.
-
-    Inspecting per request made arity a property of *how the function happened
-    to be written* rather than of the contract: ``def h(*args)`` silently
-    received one argument, and an unsupported signature failed on a user's
-    first upload rather than at startup.
-    """
-    try:
-        parameters = list(inspect.signature(handler).parameters.values())
-    except (TypeError, ValueError):
-        # Builtins and some C-implemented callables expose no signature.
-        # Assume the common shape rather than refusing to start.
-        return False
-
-    if any(parameter.kind is parameter.VAR_POSITIONAL for parameter in parameters):
-        raise TypeError(
-            f'the handler for route "{route_name}" takes *args; declare '
-            "(request) or (request, file) so the arity is unambiguous"
-        )
-
-    positional = [
-        parameter
-        for parameter in parameters
-        if parameter.kind
-        in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
-    ]
-
-    if not 1 <= len(positional) <= 2:
-        raise TypeError(
-            f'the handler for route "{route_name}" takes {len(positional)} '
-            "positional arguments; declare (request) or (request, file)"
-        )
-
-    return len(positional) == 2
 
 
 def parse_query(query_string: str) -> Dict[str, str]:

--- a/packages/pushduck-py/pushduck/router.py
+++ b/packages/pushduck-py/pushduck/router.py
@@ -346,7 +346,7 @@ class Router:
         response body.
         """
         if route.schema is not None:
-            message = route.schema.check(file)
+            message = route.schema.validate(file)
             if message:
                 raise UploadError("VALIDATION_FAILED", message)
 

--- a/packages/pushduck-py/pushduck/routes.py
+++ b/packages/pushduck-py/pushduck/routes.py
@@ -1,0 +1,285 @@
+"""Routes and their lifecycle channels.
+
+A route is a value: a dataclass whose fields are the points where an
+application gets to participate. Nothing is subclassed, nothing is registered
+by name, and nothing is discovered by reflection.
+
+That shape is not a style preference. It is the only one in which a
+misspelling fails::
+
+    Route(authorise=...)
+    TypeError: __init__() got an unexpected keyword argument 'authorise'
+
+The alternatives all resolve the hook's name at runtime — ``getattr`` on a
+subclass, a string key in a dict, a ``hasattr`` probe — and in every one of
+them ``authorise`` is silently a route with no authentication. That failure has
+a CVE in Django (2024-39330), one in Rails (2026-33173), and a live example in
+django-s3direct, where a typo'd ``auth`` key leaves the endpoint open to
+anonymous callers.
+
+The same design appears as ``sentry.ClientOptions`` in Go and
+``sentry_sdk.init(before_send=...)`` in Python — the same channels, spelled
+idiomatically per language. ``pushduck.Route`` is deliberately the same object
+in both, field for field, so one reference page documents both.
+
+Two rules decide whether a channel holds one callable or a list:
+
+* A channel that **produces a value** is a single slot. Two functions cannot
+  both *be* the object key.
+* A channel that **vetoes, wraps or observes** is a list, applied in order.
+
+Every value-producing channel is named after the value it produces, which is
+what makes "authenticate but publish no metadata" expressible without
+overloading a return value. It was the absence of that spelling — where the
+only way to say it was ``return None`` — that promoted the client's own
+metadata to authoritative in an earlier version.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field, fields, replace
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
+
+from .config import FileMeta, Schema
+from .errors import UploadError
+
+TUser = TypeVar("TUser")
+
+#: The principal of a route that does not authenticate anyone. Spelled as a
+#: type rather than ``None`` so ``Route[Anonymous]`` reads as a decision and
+#: ``ctx.user`` still has a name a reader can look up.
+class Anonymous:
+    """No authenticated principal. ``ctx.user`` is ``None``."""
+
+    __slots__ = ()
+
+
+@dataclass
+class Completion:
+    """A finished upload, as reported to ``on_complete``."""
+
+    key: str
+    file: FileMeta
+    url: str
+
+
+@dataclass
+class Context(Generic[TUser]):
+    """What every channel after ``authorize`` receives.
+
+    Carries the two metadata maps under deliberately different names. Reading
+    ``ctx.client_metadata["user_id"]`` is self-documenting as a mistake;
+    reading ``ctx.metadata["user_id"]`` is not, which is precisely how
+    CVE-2026-33173 happened in Active Storage — one hash held both the client's
+    claims and the server's flags, so setting ``identified: true`` bypassed
+    server-side content-type detection.
+    """
+
+    #: The framework-independent request. Never ``None``.
+    request: Any
+    #: The route this upload is for.
+    route: str
+    #: Whatever ``principal`` returned, or ``None`` on an anonymous route.
+    user: TUser
+    #: What the client sent. Untrusted, always. Never merged into ``metadata``.
+    client_metadata: Mapping[str, Any] = field(default_factory=dict)
+    #: What the server vouches for. Starts empty; only ``metadata`` fills it.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    #: The resolved object key. Populated before ``metadata`` runs, so metadata
+    #: can reference it; ``None`` earlier in the lifecycle.
+    key: Optional[str] = None
+
+
+# ─── channel signatures ──────────────────────────────────────────────────────
+#
+# Spelled out so a mis-typed hook is a type error at the construction site
+# rather than a surprise at the first upload.
+
+MaybeAwaitable = Union[None, Awaitable[None]]
+
+Authorize = Callable[[Any], MaybeAwaitable]
+Principal = Callable[[Any], Any]
+Around = Callable[["Context[Any]"], AsyncIterator[None]]
+Validate = Callable[["Context[Any]", FileMeta], MaybeAwaitable]
+Key = Callable[["Context[Any]", FileMeta], Union[str, Awaitable[str]]]
+Metadata = Callable[
+    ["Context[Any]", FileMeta], Union[Mapping[str, Any], Awaitable[Mapping[str, Any]]]
+]
+OnComplete = Callable[["Context[Any]", Completion], MaybeAwaitable]
+OnError = Callable[["Context[Any]", Optional[FileMeta], BaseException], MaybeAwaitable]
+
+
+@dataclass
+class Route:
+    """One named upload endpoint.
+
+    Deliberately *not* generic in the principal, though ``Context`` is. Making
+    ``Route`` generic reads well and costs more than it returns: mypy cannot
+    infer the parameter from a route that has no ``principal``, so every
+    construction site — including the common one with no authentication at all
+    — reports ``Need type annotation``. A hook that wants a typed principal
+    annotates its own parameter instead::
+
+        def tenant_key(ctx: Context[User], file: FileMeta) -> str:
+            return f"{ctx.user.tenant}/{file.name}"
+
+    which mypy checks inside the body, where the value is actually used. This is
+    the point where the Go and Python shapes legitimately diverge: Go infers
+    ``Route[T]`` from the struct literal, Python cannot.
+
+    Every channel is optional and every default means exactly one thing, so an
+    unset field can never be read as "keep whatever the client sent"::
+
+        Route(
+            schema=image(max_size="5MB"),
+            authorize=[require_session],
+            principal=load_user,
+            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            metadata=lambda ctx, f: {"owner_id": ctx.user.id},
+            on_complete=[record_upload],
+        )
+
+    Composition needs no API: a route is a value, so ``dataclasses.replace``
+    derives one from another and stays exhaustive when a channel is added
+    later::
+
+        tenant = Route(authorize=[require_session], key=tenant_key)
+        avatar = replace(tenant, schema=image(max_size="5MB"))
+    """
+
+    #: Size and type constraints. Violations are *per-file* outcomes reported
+    #: inside a 200, not request failures.
+    schema: Optional[Schema] = None
+
+    #: Runs once per request, before anything else. Raise to reject the whole
+    #: request. The return value is ignored — this channel exists so that
+    #: "check, but produce nothing" has a spelling that is not ``return None``.
+    #: Matches FastAPI's ``dependencies=[Depends(...)]``.
+    authorize: Sequence[Authorize] = ()
+
+    #: Runs once per request. Its return value *is* ``ctx.user``.
+    principal: Optional[Principal] = None
+
+    #: Async generators that bracket the whole request — one ``yield`` each,
+    #: with everything downstream running at the yield. The only channel that
+    #: can wrap rather than transform, which is what a transaction or a tracing
+    #: span needs and what an ordered list structurally cannot express.
+    around: Sequence[Around] = ()
+
+    #: Runs per file. Raise to fail *that file* while the others continue; the
+    #: failure is an entry inside a 200. The channel decides the scope, so the
+    #: same exception raised from ``authorize`` is a request-level status.
+    validate: Sequence[Validate] = ()
+
+    #: Runs per file. Its return value is a key *fragment*, not the key: the
+    #: library rejects traversal, re-sanitises every segment and appends the
+    #: disambiguator. Django moved exactly this validation into ``Storage.save``
+    #: after CVE-2024-39330, so that no override could bypass it.
+    key: Optional[Key] = None
+
+    #: Runs per file. Its return value *is* ``ctx.metadata``. The client's
+    #: metadata is never merged in.
+    metadata: Optional[Metadata] = None
+
+    #: Runs per file once an upload is confirmed.
+    on_complete: Sequence[OnComplete] = ()
+
+    #: Runs on any failure. Observational — raising here does not change the
+    #: response the caller already earned.
+    on_error: Sequence[OnError] = ()
+
+    #: Reject a completion presenting no token. Off by default so clients older
+    #: than the token keep working.
+    require_completion_token: bool = False
+
+    def __post_init__(self) -> None:
+        # Resolved once, here, rather than sniffed on every request. Sniffing
+        # per call is measurable overhead and it is how Scrapy ended up with
+        # `process_spider_output_async` — a second method name selected by
+        # suffix because the sync/async decision was never made up front.
+        for name in ("authorize", "validate", "on_complete", "on_error"):
+            object.__setattr__(self, name, tuple(_as_async(fn) for fn in getattr(self, name)))
+
+        for name in ("principal", "key", "metadata"):
+            fn = getattr(self, name)
+            if fn is not None:
+                object.__setattr__(self, name, _as_async(fn))
+
+        for fn in self.around:
+            if not inspect.isasyncgenfunction(fn):
+                raise TypeError(
+                    f"`around` takes async generators, got {getattr(fn, '__name__', fn)!r}. "
+                    "Write `async def f(ctx): ... yield ...` — everything downstream "
+                    "runs at the yield."
+                )
+        object.__setattr__(self, "around", tuple(self.around))
+
+    def describe(self) -> str:
+        """Which channels this route actually has.
+
+        Printed by ``Router.describe()`` at boot. Every comparable library —
+        Uppy, Shrine, Express, Koa, grpc-go, tRPC — is unable to answer "what
+        runs, in what order?" without reading private attributes, and tusd
+        added a ``Capabilities()`` printout for exactly this reason.
+        """
+        parts: List[str] = []
+        for f in fields(self):
+            if f.name in ("schema", "require_completion_token"):
+                continue
+            value = getattr(self, f.name)
+            if isinstance(value, tuple):
+                if value:
+                    parts.append(f"{f.name}({len(value)})")
+            elif value is not None:
+                parts.append(f.name)
+        return " ".join(parts) or "schema only"
+
+
+def _as_async(fn: Callable[..., Any]) -> Callable[..., Awaitable[Any]]:
+    """Normalise a channel to a coroutine function.
+
+    Flask and sync-Django users write ``def``; FastAPI users write
+    ``async def``. Forcing either on the other half of the ecosystem would make
+    this package feel foreign in it, so both are accepted and the difference is
+    resolved once, at registration.
+    """
+    if not callable(fn):
+        raise TypeError(f"channel entries must be callable, got {type(fn).__name__}")
+
+    if inspect.iscoroutinefunction(fn):
+        return fn
+
+    async def invoke(*args: Any) -> Any:
+        produced = fn(*args)
+        # A plain function returning an awaitable — `functools.partial` around a
+        # coroutine, or a callable object with an async `__call__` — is still
+        # async in every way that matters here.
+        if inspect.isawaitable(produced):
+            return await produced
+        return produced
+
+    invoke.__name__ = getattr(fn, "__name__", "channel")
+    invoke.__doc__ = getattr(fn, "__doc__", None)
+    return invoke
+
+
+__all__ = [
+    "Anonymous",
+    "Completion",
+    "Context",
+    "Route",
+]

--- a/packages/pushduck-py/tests/test_channels.py
+++ b/packages/pushduck-py/tests/test_channels.py
@@ -1,0 +1,474 @@
+"""The lifecycle channels, and the properties they exist to guarantee.
+
+Every test here corresponds to a failure that has a CVE, an open issue, or a
+verified bug in this repository's own history. The design is only worth its
+churn if these hold, so they are asserted rather than described.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+
+import pytest
+
+from pushduck import (
+    Completion,
+    Context,
+    FileMeta,
+    Route,
+    Router,
+    UploadConfig,
+    UploadError,
+    image,
+    file as file_schema,
+)
+from pushduck.router import Request
+
+
+CONFIG = UploadConfig(
+    bucket="test-bucket",
+    region="us-east-1",
+    access_key_id="test-key",
+    secret_access_key="test-secret",
+)
+
+
+def presign_request(files, metadata=None, headers=None):
+    body = {"files": files}
+    if metadata is not None:
+        body["metadata"] = metadata
+    return Request(
+        method="POST",
+        path="/api/upload",
+        query={"route": "avatar", "action": "presign"},
+        headers=headers or {},
+        body=json.dumps(body).encode(),
+    )
+
+
+def run(router, request):
+    return asyncio.run(router.handle(request))
+
+
+def body_of(response):
+    return json.loads(response.body)
+
+
+# ─── the channel names are resolved by Python, not by a string lookup ────────
+
+
+def test_a_misspelled_channel_is_a_typeerror():
+    """The whole reason for the dataclass.
+
+    Under every rejected alternative — a subclass, a dict of hooks, a
+    `hasattr` probe — `authorise` is a route with no authentication and no
+    diagnostic. DRF ships this failure today: `permission_class` (singular)
+    silently leaves an endpoint public.
+    """
+    with pytest.raises(TypeError, match="authorise"):
+        Route(authorise=[lambda request: None])
+
+
+def test_a_bare_schema_is_rejected_with_a_usable_message():
+    router = Router(CONFIG)
+    with pytest.raises(TypeError, match="Route"):
+        router.add("avatar", image(max_size="5MB"))
+
+
+# ─── authorize: once per request, and it vetoes the request ──────────────────
+
+
+def test_authorize_runs_once_per_request_not_once_per_file():
+    """A 50-file batch must not perform 50 session lookups.
+
+    The previous design ran the handler inside the file loop, which made the
+    endpoint an amplification primitive: one HTTP request, N authentication
+    backend calls, with no batch-size limit anywhere.
+    """
+    calls = []
+
+    router = Router(CONFIG)
+    router.add(
+        "avatar",
+        Route(schema=image(max_size="5MB"), authorize=[lambda request: calls.append(1)]),
+    )
+
+    files = [{"name": f"{n}.png", "size": 10, "type": "image/png"} for n in range(5)]
+    response = run(router, presign_request(files))
+
+    assert response.status == 200
+    assert len(body_of(response)["results"]) == 5
+    assert len(calls) == 1, f"authorize ran {len(calls)} times for 5 files"
+
+
+def test_authorize_failure_fails_the_whole_request():
+    def require_session(request):
+        raise UploadError("UNAUTHORIZED", "Sign in to upload")
+
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), authorize=[require_session]))
+
+    response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert response.status == 401
+    assert "results" not in response.body.decode()
+
+
+def test_authorize_return_value_is_ignored():
+    """`authorize` cannot smuggle metadata.
+
+    This is the channel split that closes the original bug: there is no longer
+    any way to say "authenticate" that also means "and here is the metadata",
+    so `return None` cannot be misread as consent to the client's claims.
+    """
+    router = Router(CONFIG)
+    router.add(
+        "avatar",
+        Route(schema=image(), authorize=[lambda request: {"role": "admin"}]),
+    )
+
+    response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert body_of(response)["results"][0]["metadata"] == {}
+
+
+# ─── principal produces ctx.user ─────────────────────────────────────────────
+
+
+def test_principal_becomes_ctx_user():
+    class User:
+        id = "u_42"
+        tenant = "acme"
+
+    router = Router(CONFIG)
+    router.add(
+        "avatar",
+        Route(
+            schema=image(),
+            principal=lambda request: User(),
+            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            metadata=lambda ctx, f: {"owner_id": ctx.user.id},
+        ),
+    )
+
+    result = body_of(run(router, presign_request(
+        [{"name": "me.png", "size": 10, "type": "image/png"}]
+    )))["results"][0]
+
+    assert result["key"] == "acme/me.png"
+    assert result["metadata"] == {"owner_id": "u_42"}
+
+
+# ─── metadata: the client's is never authoritative ───────────────────────────
+
+
+def test_client_metadata_is_not_promoted_when_no_metadata_channel():
+    """A route that authenticates but publishes nothing gets `{}`, not the
+    caller's claims. CVE-2026-33173 in Active Storage is this bug."""
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), authorize=[lambda r: None]))
+
+    result = body_of(run(router, presign_request(
+        [{"name": "a.png", "size": 10, "type": "image/png"}],
+        metadata={"role": "admin", "user_id": "victim"},
+    )))["results"][0]
+
+    assert result["metadata"] == {}
+
+
+def test_client_metadata_is_reachable_but_separately_named():
+    seen = {}
+
+    def metadata(ctx, f):
+        seen["client"] = dict(ctx.client_metadata)
+        seen["server"] = dict(ctx.metadata)
+        return {"trusted": True}
+
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), metadata=metadata))
+
+    result = body_of(run(router, presign_request(
+        [{"name": "a.png", "size": 10, "type": "image/png"}],
+        metadata={"role": "admin"},
+    )))["results"][0]
+
+    assert seen["client"] == {"role": "admin"}
+    assert seen["server"] == {}, "ctx.metadata must start empty"
+    assert result["metadata"] == {"trusted": True}
+
+
+# ─── key: the library owns the result ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        "../../etc/passwd",
+        "/absolute/key.png",
+        "a/../../../b.png",
+        "tenant//double.png",
+        "with?query.png",
+        "with#fragment.png",
+    ],
+)
+def test_key_channel_cannot_escape(fragment):
+    """Django moved this validation into `Storage.save()` after CVE-2024-39330
+    precisely so that no override could bypass it."""
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), key=lambda ctx, f: fragment))
+
+    response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert response.status == 500, f"{fragment!r} was accepted"
+    document = body_of(response)
+    assert document["code"] == "CONFIG_INVALID"
+    # The message names the channel and says what to return instead: this is a
+    # bug in the application, and the person reading it is the one who can fix
+    # it.
+    assert "`key` channel" in document["detail"]
+
+
+def test_key_channel_output_is_re_sanitised():
+    """Without this, the non-Latin filename handling protects only the default
+    key and is bypassed by every application that supplies its own."""
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), key=lambda ctx, f: f"tenant/{f.name}"))
+
+    result = body_of(run(router, presign_request(
+        [{"name": "写真 photo.png", "size": 10, "type": "image/png"}]
+    )))["results"][0]
+
+    assert result["key"].startswith("tenant/")
+    assert "写真" in result["key"], "non-Latin characters must survive"
+    assert " " not in result["key"], "spaces must be sanitised"
+
+
+# ─── validate: per-file, while the batch continues ───────────────────────────
+
+
+def test_validate_fails_one_file_not_the_request():
+    def reject_svg(ctx, f):
+        if f.type == "image/svg+xml":
+            raise UploadError("VALIDATION_FAILED", "SVG avatars are not allowed")
+
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=file_schema(max_size="5MB"), validate=[reject_svg]))
+
+    response = run(router, presign_request([
+        {"name": "ok.png", "size": 10, "type": "image/png"},
+        {"name": "bad.svg", "size": 10, "type": "image/svg+xml"},
+        {"name": "also-ok.png", "size": 10, "type": "image/png"},
+    ]))
+
+    assert response.status == 200
+    results = body_of(response)["results"]
+    assert [r["success"] for r in results] == [True, False, True]
+    assert results[1]["error"] == "SVG avatars are not allowed"
+
+
+def test_schema_violation_is_also_per_file():
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(max_size="1KB")))
+
+    results = body_of(run(router, presign_request([
+        {"name": "small.png", "size": 10, "type": "image/png"},
+        {"name": "huge.png", "size": 999_999, "type": "image/png"},
+    ])))["results"]
+
+    assert [r["success"] for r in results] == [True, False]
+    assert "exceeds maximum" in results[1]["error"]
+
+
+# ─── around: the only channel that wraps ─────────────────────────────────────
+
+
+def test_around_brackets_the_request():
+    order = []
+
+    async def outer(ctx):
+        order.append("outer:enter")
+        yield
+        order.append("outer:exit")
+
+    async def inner(ctx):
+        order.append("inner:enter")
+        yield
+        order.append("inner:exit")
+
+    router = Router(CONFIG)
+    router.add(
+        "avatar",
+        Route(
+            schema=image(),
+            around=[outer, inner],
+            key=lambda ctx, f: order.append("body") or f.name,
+        ),
+    )
+
+    run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert order == ["outer:enter", "inner:enter", "body", "inner:exit", "outer:exit"]
+
+
+def test_around_exits_on_failure():
+    """The property Django rewrote its middleware layer to guarantee: an
+    entered wrapper is always exited, so a transaction cannot leak."""
+    events = []
+
+    async def transaction(ctx):
+        events.append("begin")
+        try:
+            yield
+        except Exception:
+            events.append("rollback")
+            raise
+        else:
+            events.append("commit")
+
+    def explode(ctx, f):
+        raise RuntimeError("handler blew up")
+
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), around=[transaction], key=explode))
+
+    response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert response.status == 500
+    assert events == ["begin", "rollback"]
+
+
+def test_around_rejects_a_plain_function_at_registration():
+    with pytest.raises(TypeError, match="async generators"):
+        Route(around=[lambda ctx: None])
+
+
+# ─── on_complete ─────────────────────────────────────────────────────────────
+
+
+def test_on_complete_receives_server_metadata():
+    seen = []
+
+    router = Router(CONFIG)
+    router.add(
+        "avatar",
+        Route(
+            schema=image(),
+            metadata=lambda ctx, f: {"owner": "u_42"},
+            on_complete=[lambda ctx, done: seen.append((done.key, dict(ctx.metadata)))],
+        ),
+    )
+
+    request = Request(
+        method="POST",
+        path="/api/upload",
+        query={"route": "avatar", "action": "complete"},
+        headers={},
+        body=json.dumps({
+            "completions": [{
+                "key": "avatars/me.png",
+                "file": {"name": "me.png", "size": 10, "type": "image/png"},
+                "metadata": {"owner": "attacker"},
+            }]
+        }).encode(),
+    )
+
+    response = run(router, request)
+
+    assert response.status == 200
+    assert seen == [("avatars/me.png", {"owner": "u_42"})], "client metadata must not win"
+
+
+# ─── composition and introspection ───────────────────────────────────────────
+
+
+def test_replace_derives_a_route():
+    """Composition needs no API because a route is a value."""
+    tenant = Route(authorize=[lambda r: None], key=lambda ctx, f: f"t/{f.name}")
+    avatar = replace(tenant, schema=image(max_size="5MB"))
+
+    assert avatar.authorize == tenant.authorize
+    assert avatar.schema is not None
+    assert tenant.schema is None
+
+
+def test_router_defaults_prepend_rather_than_replace():
+    """DRF's `permission_classes` replaces the global default, so adding one
+    route-specific rule silently drops the global one. This must not."""
+    calls = []
+
+    router = Router(CONFIG, defaults=Route(authorize=[lambda r: calls.append("global")]))
+    router.add("avatar", Route(schema=image(), authorize=[lambda r: calls.append("route")]))
+
+    run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
+
+    assert calls == ["global", "route"]
+
+
+def test_describe_lists_channels():
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image(), authorize=[lambda r: None], key=lambda c, f: "k"))
+    router.add("public", Route(schema=file_schema()))
+
+    described = router.describe()
+
+    assert "authorize(1)" in described
+    assert "key" in described
+    assert "schema only" in described
+
+
+# ─── the unauthenticated crash ───────────────────────────────────────────────
+
+
+def test_a_non_latin1_action_is_a_problem_document_not_a_crash():
+    """`?action=☃` reached an ASGI header encode outside every handler."""
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image()))
+
+    response = run(router, Request(
+        method="GET", path="/api/upload",
+        query={"route": "avatar", "action": "☃"}, headers={}, body=b"",
+    ))
+
+    assert response.status == 400
+    for value in response.headers.values():
+        value.encode("latin-1")  # must not raise
+
+
+def test_an_unknown_route_name_is_not_reflected_into_a_header():
+    router = Router(CONFIG)
+    router.add("avatar", Route(schema=image()))
+
+    response = run(router, Request(
+        method="POST", path="/api/upload",
+        query={"route": "☃", "action": "presign"}, headers={}, body=b"{}",
+    ))
+
+    assert response.status == 404
+    for value in response.headers.values():
+        value.encode("latin-1")
+
+
+# ─── sync and async are both first-class ─────────────────────────────────────
+
+
+def test_sync_and_async_channels_interoperate():
+    """Flask users write `def`; FastAPI users write `async def`. Both, in one
+    route, resolved once at registration."""
+    async def async_principal(request):
+        return {"id": "u_1"}
+
+    def sync_metadata(ctx, f):
+        return {"owner": ctx.user["id"]}
+
+    router = Router(CONFIG)
+    router.add("avatar", Route(
+        schema=image(), principal=async_principal, metadata=sync_metadata
+    ))
+
+    result = body_of(run(router, presign_request(
+        [{"name": "a.png", "size": 10, "type": "image/png"}]
+    )))["results"][0]
+
+    assert result["metadata"] == {"owner": "u_1"}

--- a/packages/pushduck-py/tests/test_docs_snippets.py
+++ b/packages/pushduck-py/tests/test_docs_snippets.py
@@ -1,0 +1,98 @@
+"""Every Python snippet on the docs page, executed.
+
+`docs/content/docs/integrations/python.mdx` states that its snippets are
+tested. This is the test, and it asserts the *outputs* the page prints — the
+sanitised key and the `describe()` listing — not merely that the code runs.
+
+Three times in this project a documented API turned out not to exist. The page
+is only trustworthy if something executes it.
+"""
+import os, asyncio
+
+
+def test_every_documented_snippet_runs() -> None:
+    _body()
+
+
+def _body() -> None:
+    from dataclasses import replace
+    from pushduck import Router, Route, UploadConfig, image, file, UploadError
+
+    os.environ.setdefault("AWS_S3_BUCKET","b"); os.environ.setdefault("AWS_REGION","us-east-1")
+    os.environ.setdefault("AWS_ACCESS_KEY_ID","k"); os.environ.setdefault("AWS_SECRET_ACCESS_KEY","s")
+
+    class User: id="u1"; tenant="acme"
+    def require_session(request): pass
+    def load_user(request): return User()
+    def record_upload(ctx, done): pass
+    def current_tenant(): return "t1"
+    def tenant_key(ctx, f): return f"{ctx.user.tenant}/{f.name}"
+
+    config = UploadConfig(
+        bucket=os.environ["AWS_S3_BUCKET"], region=os.environ["AWS_REGION"],
+        access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        session_token=os.environ.get("AWS_SESSION_TOKEN"),
+    )
+    router = Router(config)
+
+    # --- snippet 1: defining routes
+    router.add("imageUpload", Route(
+        schema=image(max_size="5MB"),
+        authorize=[require_session],
+        principal=load_user,
+        key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+        metadata=lambda ctx, f: {"user_id": ctx.user.id},
+        on_complete=[record_upload],
+    ))
+    router.add("documentUpload", Route(
+        schema=file(max_size="50MB", allow_types=["application/pdf"]),
+        metadata=lambda ctx, f: {"tenant": current_tenant()},
+    ))
+    assert "imageUpload" in router.routes and "documentUpload" in router.routes
+
+    # --- snippet 2: forwarding client metadata explicitly
+    r2 = Router(config)
+    r2.add("public", Route(metadata=lambda ctx, f: dict(ctx.client_metadata)))
+    assert "public" in r2.routes
+
+    # --- snippet 3: the key claims, verified by running them
+    import json
+    from pushduck.router import Request
+    def presign(rt, name):
+        rr = Router(config); rr.add("x", rt)
+        resp = asyncio.run(rr.handle(Request("POST","/u",{"route":"x"},{},
+            json.dumps({"files":[{"name":name,"size":10,"type":"image/png"}]}).encode())))
+        return resp.status, json.loads(resp.body)
+
+    st, body = presign(Route(schema=image(), principal=load_user, key=tenant_key), "写真 photo.png")
+    assert st == 200, body
+    got = body["results"][0]["key"]
+    assert got == "acme/写真_photo.png", f"docs claim acme/写真_photo.png, got {got!r}"
+
+
+    st, body = presign(Route(schema=image(), key=lambda ctx,f: "../../etc/passwd"), "a.png")
+    assert st == 500 and body["code"] == "CONFIG_INVALID", body
+
+
+    # --- snippet 4: replace()
+    tenant = Route(authorize=[require_session], principal=load_user, key=tenant_key)
+    r3 = Router(config)
+    r3.add("avatar",   replace(tenant, schema=image(max_size="5MB")))
+    r3.add("document", replace(tenant, schema=file(max_size="50MB")))
+    assert r3.routes["avatar"].schema is not None
+
+    # --- snippet 5: router defaults
+    r4 = Router(config, defaults=Route(authorize=[require_session]))
+    assert r4.defaults is not None
+
+    # --- snippet 6: describe(), and the exact output the docs print
+    r5 = Router(config)
+    r5.add("avatar", Route(schema=image(), authorize=[require_session], principal=load_user,
+                           key=tenant_key, metadata=lambda c,f: {}, on_complete=[record_upload]))
+    r5.add("public", Route(schema=file()))
+    described = r5.describe()
+
+    assert "authorize(1) principal key metadata on_complete(1)" in described, described
+    assert "schema only" in described, described
+

--- a/packages/pushduck-py/tests/test_frameworks.py
+++ b/packages/pushduck-py/tests/test_frameworks.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from pushduck import Request, Router, UploadConfig, UploadError, image  # noqa: E402
+from pushduck import Request, Route, Router, UploadConfig, UploadError, image  # noqa: E402
 
 
 def installed(module: str) -> bool:
@@ -45,11 +45,18 @@ def build_router() -> Router:
         )
     )
 
-    @router.route("imageUpload", image(max_size="5MB"))
-    def image_upload(request: Request) -> dict:
+    def require_token(request: Request) -> None:
         if request.header("authorization") != "Bearer token":
             raise UploadError("UNAUTHORIZED", "Sign in to upload")
-        return {"userId": "u1"}
+
+    router.add(
+        "imageUpload",
+        Route(
+            schema=image(max_size="5MB"),
+            authorize=[require_token],
+            metadata=lambda ctx, f: {"userId": "u1"},
+        ),
+    )
 
     return router
 

--- a/packages/pushduck-py/tests/test_interop.py
+++ b/packages/pushduck-py/tests/test_interop.py
@@ -154,11 +154,11 @@ class ValidationAgreement(unittest.TestCase):
         route = image(max_size="5MB")
         from pushduck import FileMeta
 
-        message = route.check(FileMeta("huge.jpg", 50 * 1024 * 1024, "image/jpeg"))
+        message = route.validate(FileMeta("huge.jpg", 50 * 1024 * 1024, "image/jpeg"))
         self.assertEqual(message, "File size 50.0MB exceeds maximum 5.0MB")
 
-        self.assertIsNone(route.check(FileMeta("a.png", 10, "image/png")))
-        self.assertIsNotNone(route.check(FileMeta("a.pdf", 10, "application/pdf")))
+        self.assertIsNone(route.validate(FileMeta("a.png", 10, "image/png")))
+        self.assertIsNotNone(route.validate(FileMeta("a.pdf", 10, "application/pdf")))
 
 
 class CompletionTokens(unittest.TestCase):

--- a/packages/pushduck-py/tests/test_interop.py
+++ b/packages/pushduck-py/tests/test_interop.py
@@ -154,11 +154,11 @@ class ValidationAgreement(unittest.TestCase):
         route = image(max_size="5MB")
         from pushduck import FileMeta
 
-        message = route.validate(FileMeta("huge.jpg", 50 * 1024 * 1024, "image/jpeg"))
+        message = route.check(FileMeta("huge.jpg", 50 * 1024 * 1024, "image/jpeg"))
         self.assertEqual(message, "File size 50.0MB exceeds maximum 5.0MB")
 
-        self.assertIsNone(route.validate(FileMeta("a.png", 10, "image/png")))
-        self.assertIsNotNone(route.validate(FileMeta("a.pdf", 10, "application/pdf")))
+        self.assertIsNone(route.check(FileMeta("a.png", 10, "image/png")))
+        self.assertIsNotNone(route.check(FileMeta("a.pdf", 10, "application/pdf")))
 
 
 class CompletionTokens(unittest.TestCase):
@@ -190,30 +190,28 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class HandlerContract(unittest.TestCase):
-    """What a handler returns decides the upload's metadata, deterministically.
+class ChannelContract(unittest.TestCase):
+    """The metadata channel decides the upload's metadata, and nothing else does.
 
-    The previous contract inferred too much. A handler returning ``None`` — the
-    most natural shape for one that only authenticates — caused the *client's*
-    metadata to become authoritative, so a caller could assert
-    ``{"userId": "someone-else"}`` and have the application read it as though
-    the server had vouched for it. Returning a non-mapping did the same, quietly.
+    The contract this replaces inferred too much from a single return value. A
+    handler that returned ``None`` — the natural shape for one that only
+    authenticates — promoted the *client's* metadata to authoritative, so a
+    caller could assert ``{"userId": "someone-else"}`` and have the application
+    read it as though the server had vouched for it.
+
+    The channel design removes the inference rather than correcting it: there is
+    no longer a return value that means two things.
     """
 
     @staticmethod
-    def presign(handler, client_metadata):
+    def presign(route, client_metadata):
         import asyncio
         import json as _json
 
-        from pushduck import Request, Router, UploadConfig, file as file_route
+        from pushduck import Request, Router, UploadConfig
 
-        router = Router(
-            UploadConfig(bucket="b", access_key_id="k", secret_access_key="s")
-        )
-        if handler is None:
-            router.add_route("up", file_route())
-        else:
-            router.route("up", file_route())(handler)
+        router = Router(UploadConfig(bucket="b", access_key_id="k", secret_access_key="s"))
+        router.add("up", route)
 
         response = asyncio.run(
             router.handle(
@@ -235,49 +233,79 @@ class HandlerContract(unittest.TestCase):
 
     SPOOFED = {"userId": "attacker", "role": "admin"}
 
-    def test_a_returned_mapping_replaces_the_client_metadata(self) -> None:
-        status, body = self.presign(lambda request: {"userId": "real"}, self.SPOOFED)
+    def test_the_metadata_channel_replaces_the_client_metadata(self) -> None:
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(
+            Route(schema=file_route(), metadata=lambda ctx, f: {"userId": "real"}),
+            self.SPOOFED,
+        )
         self.assertEqual(status, 200)
         # Replaced, not merged: `role` must not survive.
         self.assertEqual(body["results"][0]["metadata"], {"userId": "real"})
 
-    def test_returning_none_leaves_no_metadata(self) -> None:
-        status, body = self.presign(lambda request: None, self.SPOOFED)
+    def test_no_metadata_channel_leaves_no_metadata(self) -> None:
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(
+            Route(schema=file_route(), authorize=[lambda request: None]), self.SPOOFED
+        )
         self.assertEqual(status, 200)
         self.assertEqual(
             body["results"][0]["metadata"], {},
-            "a handler that returned nothing must not promote the client's claims",
+            "a route that publishes no metadata must not promote the client's claims",
         )
 
-    def test_returning_a_non_mapping_is_a_loud_failure(self) -> None:
-        # Silently falling back to the client's metadata is how the previous
-        # contract turned a typo into an authorisation bug.
-        status, body = self.presign(lambda request: "oops", self.SPOOFED)
-        self.assertGreaterEqual(status, 500)
-        self.assertNotIn("attacker", json.dumps(body))
+    def test_a_route_with_no_channels_still_publishes_nothing(self) -> None:
+        """The change of behaviour, asserted deliberately.
 
-    def test_a_route_without_a_handler_passes_the_client_metadata_through(self) -> None:
-        # Explicitly public: there is no handler to have an opinion, and this
-        # matches a route with no middleware in the other implementations.
-        status, body = self.presign(None, {"albumId": "summer"})
+        A public route used to forward the client's metadata as the upload's,
+        which made "I forgot to add a handler" and "I trust this caller"
+        indistinguishable on the wire. Forwarding it is still available — it is
+        now something an application *writes*, and can be grepped for.
+        """
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(Route(schema=file_route()), {"albumId": "summer"})
+        self.assertEqual(status, 200)
+        self.assertEqual(body["results"][0]["metadata"], {})
+
+    def test_forwarding_client_metadata_is_available_and_explicit(self) -> None:
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(
+            Route(
+                schema=file_route(),
+                metadata=lambda ctx, f: dict(ctx.client_metadata),
+            ),
+            {"albumId": "summer"},
+        )
         self.assertEqual(status, 200)
         self.assertEqual(body["results"][0]["metadata"], {"albumId": "summer"})
 
-    def test_the_file_is_available_to_a_two_argument_handler(self) -> None:
-        status, body = self.presign(lambda request, file: {"name": file.name}, {})
+    def test_returning_a_non_mapping_is_a_loud_failure(self) -> None:
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(
+            Route(schema=file_route(), metadata=lambda ctx, f: "oops"), self.SPOOFED
+        )
+        self.assertGreaterEqual(status, 500)
+        self.assertNotIn("attacker", json.dumps(body))
+
+    def test_the_file_is_available_to_every_per_file_channel(self) -> None:
+        from pushduck import Route, file as file_route
+
+        status, body = self.presign(
+            Route(schema=file_route(), metadata=lambda ctx, f: {"name": f.name}), {}
+        )
         self.assertEqual(status, 200)
         self.assertEqual(body["results"][0]["metadata"], {"name": "a.jpg"})
 
-    def test_an_ambiguous_signature_fails_at_registration(self) -> None:
-        # At import time with the route's name, rather than on a user's first
-        # upload with a TypeError from inside the library.
-        from pushduck import Router, UploadConfig, file as file_route
-
-        router = Router(UploadConfig(bucket="b"))
+    def test_a_misspelled_channel_fails_at_import(self) -> None:
+        """At import time, naming the field — rather than on a user's first
+        upload, or not at all."""
+        from pushduck import Route
 
         with self.assertRaises(TypeError) as caught:
-            router.route("up", file_route())(lambda *args: {})
-        self.assertIn("up", str(caught.exception))
-
-        with self.assertRaises(TypeError):
-            router.route("up", file_route())(lambda: {})
+            Route(authorise=[lambda request: None])
+        self.assertIn("authorise", str(caught.exception))

--- a/packages/pushduck-py/tests/test_multipart.py
+++ b/packages/pushduck-py/tests/test_multipart.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from pushduck import Request, Router, UploadConfig, UploadError, file  # noqa: E402
+from pushduck import Request, Route, Router, UploadConfig, UploadError, file  # noqa: E402
 from pushduck.config import MAX_PARTS, MIN_PART_SIZE, choose_part_size  # noqa: E402
 from pushduck.multipart import sign_session, verify_session  # noqa: E402
 
@@ -128,7 +128,7 @@ class SessionAuthorisation(unittest.TestCase):
 
     def test_signing_rejects_a_forged_session(self) -> None:
         router = self.router()
-        router.add_route("bigUpload", file(max_size="500MB"))
+        router.add("bigUpload", Route(schema=file(max_size="500MB")))
 
         status, body = call(
             router, "multipart-sign",
@@ -141,8 +141,8 @@ class SessionAuthorisation(unittest.TestCase):
         # Otherwise a session minted on a permissive route signs parts on a
         # strict one.
         router = self.router()
-        router.add_route("bigUpload", file(max_size="500MB"))
-        router.add_route("otherUpload", file(max_size="500MB"))
+        router.add("bigUpload", Route(schema=file(max_size="500MB")))
+        router.add("otherUpload", Route(schema=file(max_size="500MB")))
 
         token = sign_session(
             "conformance-secret",
@@ -157,7 +157,7 @@ class SessionAuthorisation(unittest.TestCase):
         # Signing one would authorise a write past the end of the object the
         # session was created for.
         router = self.router()
-        router.add_route("bigUpload", file(max_size="500MB"))
+        router.add("bigUpload", Route(schema=file(max_size="500MB")))
 
         token = sign_session(
             "conformance-secret",
@@ -170,7 +170,7 @@ class SessionAuthorisation(unittest.TestCase):
 
     def test_signs_a_part_within_the_plan(self) -> None:
         router = self.router()
-        router.add_route("bigUpload", file(max_size="500MB"))
+        router.add("bigUpload", Route(schema=file(max_size="500MB")))
 
         total = 12 * 1024 * 1024
         token = sign_session(
@@ -189,7 +189,7 @@ class SessionAuthorisation(unittest.TestCase):
         # client writes past the end of its own file.
         self.assertEqual(body[1]["size"], total - 2 * MIN_PART_SIZE)
 
-    def test_the_route_handler_runs_on_every_multipart_call(self) -> None:
+    def test_authorize_runs_on_every_multipart_call(self) -> None:
         # The token proves which object is acted on; the handler proves the
         # caller is still allowed to act. Checking only the token would let a
         # revoked user finish an upload they started.
@@ -197,11 +197,11 @@ class SessionAuthorisation(unittest.TestCase):
             UploadConfig(bucket="b", access_key_id="k", secret_access_key="conformance-secret")
         )
 
-        @router.route("bigUpload", file(max_size="500MB"))
-        def guard(request: Request) -> dict:
+        def guard(request: Request) -> None:
             if request.header("authorization") != "Bearer ok":
                 raise UploadError("UNAUTHORIZED", "Sign in to upload")
-            return {}
+
+        router.add("bigUpload", Route(schema=file(max_size="500MB"), authorize=[guard]))
 
         token = sign_session(
             "conformance-secret",
@@ -210,7 +210,7 @@ class SessionAuthorisation(unittest.TestCase):
         )
 
         status, _ = call(router, "multipart-sign", {"session": token, "partNumbers": [1]})
-        self.assertEqual(status, 401, "a valid session must not bypass the route handler")
+        self.assertEqual(status, 401, "a valid session must not bypass the route's authorize channel")
 
 
 class PartPlanning(unittest.TestCase):
@@ -243,7 +243,7 @@ class MinioRoundTrip(unittest.TestCase):
             force_path_style=True,
         )
         self.router = Router(self.config)
-        self.router.add_route("bigUpload", file(max_size="500MB"))
+        self.router.add("bigUpload", Route(schema=file(max_size="500MB")))
 
     @staticmethod
     def patterned(size: int) -> bytes:


### PR DESCRIPTION
Tops off the stack: named lifecycle channels for the Python server, library-owned key generation, executable docs snippets, and the Schema.validate rename (one word per concept — the channel is `validate` and the error code is `VALIDATION_FAILED`; `check` was a third spelling).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added declarative Python route configuration with reusable authorization, validation, metadata, key, lifecycle, and completion channels.
  * Added router defaults, route composition, capability descriptions, and public `Schema` and key-resolution utilities.
  * Added stricter custom key validation, including path-traversal and size-limit protection.
* **Documentation**
  * Updated Python integration examples for the new route configuration API.
* **Bug Fixes**
  * Improved multipart authorization handling and error reporting for invalid route or action names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->