### PR TITLE
feat: beta API redesign (v0.6.0) — beta into main

### DIFF
--- a/packages/pushduck/src/__tests__/expires-in.test.ts
+++ b/packages/pushduck/src/__tests__/expires-in.test.ts
@@ -170,26 +170,26 @@ describe(".middleware() config preservation (regression)", () => {
     expect(route._getConfig().paths?.prefix).toBe("uploads");
   });
 
-  it("preserves onUploadComplete when .middleware() is called after", () => {
+  it("preserves onComplete when .middleware() is called after", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
     const route = s3
       .file()
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ userId: "123" }));
 
-    expect(route._getConfig().onUploadComplete).toBe(hook);
+    expect(route._getConfig().onComplete).toBe(hook);
   });
 
   it("preserves all config when multiple .middleware() calls are chained", () => {
     const { s3 } = makeS3();
     const hook = vi.fn();
-    // expiresIn and onUploadComplete start an S3Route; paths and further
+    // expiresIn and onComplete start an S3Route; paths and further
     // middleware calls must also preserve the accumulated config
     const route = s3
       .file()
       .expiresIn(600)
-      .onUploadComplete(hook)
+      .onComplete(hook)
       .middleware(async () => ({ step: 1 }))
       .paths({ prefix: "docs" })
       .middleware(async ({ metadata }) => ({ ...metadata, step: 2 }));
@@ -197,7 +197,7 @@ describe(".middleware() config preservation (regression)", () => {
     const config = route._getConfig();
     expect(config.expiresIn).toBe(600);
     expect(config.paths?.prefix).toBe("docs");
-    expect(config.onUploadComplete).toBe(hook);
+    expect(config.onComplete).toBe(hook);
     expect(config.middleware).toHaveLength(2);
   });
 

--- a/packages/pushduck/src/__tests__/react-component.test.tsx
+++ b/packages/pushduck/src/__tests__/react-component.test.tsx
@@ -185,7 +185,7 @@ describe("React binding in a rendered component", () => {
       <BlockingUploader fetcher={createFetcher()} transport={() => blocked} />
     );
 
-    let settle!: Promise<void>;
+    let settle!: Promise<unknown>;
     await act(async () => {
       settle = controls.uploadFiles([makeFile()]);
       // Let the presign round trip land, but not the transfer.

--- a/packages/pushduck/src/client.ts
+++ b/packages/pushduck/src/client.ts
@@ -236,6 +236,9 @@ export type {
  * });
  * ```
  */
+// Preferred: hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================
@@ -347,6 +350,11 @@ export type {
   S3Router,
   TypedRouteHook,
   TypedUploadedFile,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";
 
 /**

--- a/packages/pushduck/src/core/config/upload-config.ts
+++ b/packages/pushduck/src/core/config/upload-config.ts
@@ -757,13 +757,20 @@ export class UploadConfigBuilder {
     // Create storage instance with config
     const storage = createStorage(finalConfig);
 
-    // Create S3 builder instance with config
-    const s3 = createS3Instance(finalConfig);
+    // Create upload builder instance with config
+    const upload = createS3Instance(finalConfig);
 
     return {
       config: finalConfig,
       storage,
-      s3,
+      upload,
+      /** @deprecated Use `upload` instead. The `s3` name is misleading when using R2, MinIO, or other providers. */
+      get s3() {
+        console.warn(
+          '⚠️ pushduck: Destructuring `s3` from build() is deprecated. Use `upload` instead: const { upload } = createUploadConfig()...build()'
+        );
+        return upload;
+      },
     };
   }
 }
@@ -799,7 +806,12 @@ export interface UploadInitResult {
   config: UploadConfig;
   /** Storage instance for file operations (list, delete, info, etc.) */
   storage: StorageInstance;
-  /** S3 builder instance with schema builders and router factory */
+  /** Provider-neutral upload builder with schema builders and router factory */
+  upload: ReturnType<typeof createS3Instance>;
+  /**
+   * @deprecated Use `upload` instead.
+   * The `s3` name is misleading when using Cloudflare R2, MinIO, or other providers.
+   */
   s3: ReturnType<typeof createS3Instance>;
 }
 

--- a/packages/pushduck/src/core/router/router-v2.ts
+++ b/packages/pushduck/src/core/router/router-v2.ts
@@ -162,10 +162,25 @@ export interface S3LifecycleContext<T = any> {
   file: S3FileMetadata;
   /** Processed metadata from middleware */
   metadata: T;
-  /** Public URL of the uploaded file (available after upload) */
-  url?: string;
-  /** Storage key/path of the uploaded file */
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public URL of the uploaded file. Never expires if bucket has public access.
+   * Store this in your database.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key?: string;
+  /** @deprecated Use `publicUrl` or `presignedUrl` instead. */
+  url?: string;
 }
 
 /**
@@ -417,8 +432,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   paths(paths: S3RoutePathConfig<TMetadata>): this {
-    this.config.paths = { ...this.config.paths, ...paths };
-    return this;
+    const newConfig = { ...this.config, paths: { ...this.config.paths, ...paths } };
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**
@@ -491,23 +506,26 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
 
     if (typeof secondsOrConfig === "number") {
       assertRange("expiresIn", secondsOrConfig);
-      this.config.expiresIn = secondsOrConfig;
-      return this;
+      return new S3Route(this.schema, {
+        ...this.config,
+        expiresIn: secondsOrConfig,
+      }) as this;
     }
 
     const { upload, download } = secondsOrConfig;
+    const newConfig = { ...this.config };
 
     if (upload !== undefined) {
       assertRange("expiresIn.upload", upload);
-      this.config.expiresIn = upload;
+      newConfig.expiresIn = upload;
     }
 
     if (download !== undefined) {
       assertRange("expiresIn.download", download);
-      this.config.downloadExpiresIn = download;
+      newConfig.downloadExpiresIn = download;
     }
 
-    return this;
+    return new S3Route(this.schema, newConfig) as this;
   }
 
   /**
@@ -538,8 +556,8 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * ```
    */
   onUploadStart(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadStart = hook;
-    return this;
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return this.onStart(hook);
   }
 
   /**
@@ -548,34 +566,85 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    *
    * @param hook - Function to execute on upload progress
    * @returns This route instance for chaining
-   *
-   * @example Progress Tracking
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await updateUploadProgress(metadata.uploadId, {
-   *     fileName: file.name,
-   *     progress,
-   *     status: progress === 100 ? 'completing' : 'uploading',
-   *   });
-   * });
-   * ```
-   *
-   * @example Real-time Updates
-   * ```typescript
-   * const route = s3.file().onUploadProgress(async ({ file, metadata, progress }) => {
-   *   await sendProgressUpdate(metadata.userId, {
-   *     fileName: file.name,
-   *     percentComplete: progress,
-   *   });
-   * });
-   * ```
+   * @deprecated Use `.onProgress()` instead.
    */
   onUploadProgress(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { progress: number }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadProgress = hook;
+    console.warn('⚠️ pushduck: .onUploadProgress() is deprecated. Use .onProgress() instead.');
+    return this.onProgress(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   * Ideal for database updates, post-processing, and success notifications.
+   *
+   * @param hook - Function to execute on upload completion
+   * @returns This route instance for chaining
+   * @deprecated Use `.onComplete()` instead.
+   */
+  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return this.onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   * Essential for error logging, cleanup, and user notifications.
+   *
+   * @param hook - Function to execute on upload error
+   * @returns This route instance for chaining
+   * @deprecated Use `.onError()` instead.
+   */
+  onUploadError(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { error: Error }
+    ) => Promise<void> | void
+  ): this {
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return this.onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   * Useful for logging, initializing progress tracking, or sending notifications.
+   *
+   * @param hook - Function to execute on upload start
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onStart = hook;
+    return this;
+  }
+
+  /**
+   * Adds a hook that executes during file upload progress.
+   *
+   * @param hook - Function to execute on upload progress
+   * @returns This route instance for chaining
+   *
+   * @example
+   * ```typescript
+   * upload.file().onProgress(async ({ file, metadata, progress }) => {
+   *   await updateUploadProgress(metadata.uploadId, { progress });
+   * });
+   * ```
+   */
+  onProgress(
+    hook: (
+      ctx: S3LifecycleContext<TMetadata> & { progress: number }
+    ) => Promise<void> | void
+  ): this {
+    this.config.onProgress = hook;
     return this;
   }
 
@@ -586,100 +655,37 @@ export class S3Route<TSchema extends S3Schema = S3Schema, TMetadata = any> {
    * @param hook - Function to execute on upload completion
    * @returns This route instance for chaining
    *
-   * @example Database Update
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, key, metadata }) => {
-   *   await db.files.create({
-   *     name: file.name,
-   *     size: file.size,
-   *     type: file.type,
-   *     url: url,
-   *     key: key,
-   *     uploadedBy: metadata.userId,
-   *     uploadedAt: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Post-processing
-   * ```typescript
-   * const route = s3.image().onUploadComplete(async ({ file, key, metadata }) => {
-   *   // Generate thumbnails for images
-   *   await generateThumbnails(key, {
-   *     sizes: [100, 300, 600],
-   *     userId: metadata.userId,
-   *   });
-   * });
-   * ```
-   *
-   * @example Notification System
-   * ```typescript
-   * const route = s3.file().onUploadComplete(async ({ file, url, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_success',
-   *     message: `File "${file.name}" uploaded successfully`,
-   *     fileUrl: url,
-   *   });
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
    * });
    * ```
    */
-  onUploadComplete(hook: S3LifecycleHook<TMetadata>): this {
-    this.config.onUploadComplete = hook;
+  onComplete(hook: S3LifecycleHook<TMetadata>): this {
+    this.config.onComplete = hook;
     return this;
   }
 
   /**
    * Adds a hook that executes when file upload fails.
-   * Essential for error logging, cleanup, and user notifications.
    *
    * @param hook - Function to execute on upload error
    * @returns This route instance for chaining
    *
-   * @example Error Logging
+   * @example
    * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   console.error(`Upload failed: ${file.name}`, error);
-   *   await logUploadError({
-   *     fileName: file.name,
-   *     error: error.message,
-   *     stack: error.stack,
-   *     userId: metadata.userId,
-   *     timestamp: new Date(),
-   *   });
-   * });
-   * ```
-   *
-   * @example Cleanup and Retry
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   // Clean up any partial uploads
-   *   await cleanupPartialUpload(file.name, metadata.uploadId);
-   *
-   *   // Queue for retry if appropriate
-   *   if (isRetryableError(error)) {
-   *     await queueUploadRetry(file.name, metadata);
-   *   }
-   * });
-   * ```
-   *
-   * @example User Notification
-   * ```typescript
-   * const route = s3.file().onUploadError(async ({ file, error, metadata }) => {
-   *   await sendNotification({
-   *     userId: metadata.userId,
-   *     type: 'upload_error',
-   *     message: `Failed to upload "${file.name}": ${error.message}`,
-   *   });
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
    * });
    * ```
    */
-  onUploadError(
+  onError(
     hook: (
       ctx: S3LifecycleContext<TMetadata> & { error: Error }
     ) => Promise<void> | void
   ): this {
-    this.config.onUploadError = hook;
+    this.config.onError = hook;
     return this;
   }
 
@@ -727,14 +733,26 @@ interface S3RouteConfig<TMetadata = any> {
    */
   requireCompletionToken?: boolean;
   /** Hook for upload start events */
-  onUploadStart?: S3LifecycleHook<TMetadata>;
+  onStart?: S3LifecycleHook<TMetadata>;
   /** Hook for upload progress events */
-  onUploadProgress?: (
+  onProgress?: (
     ctx: S3LifecycleContext<TMetadata> & { progress: number }
   ) => Promise<void> | void;
   /** Hook for upload completion events */
-  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  onComplete?: S3LifecycleHook<TMetadata>;
   /** Hook for upload error events */
+  onError?: (
+    ctx: S3LifecycleContext<TMetadata> & { error: Error }
+  ) => Promise<void> | void;
+  /** @deprecated Use onStart */
+  onUploadStart?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onProgress */
+  onUploadProgress?: (
+    ctx: S3LifecycleContext<TMetadata> & { progress: number }
+  ) => Promise<void> | void;
+  /** @deprecated Use onComplete */
+  onUploadComplete?: S3LifecycleHook<TMetadata>;
+  /** @deprecated Use onError */
   onUploadError?: (
     ctx: S3LifecycleContext<TMetadata> & { error: Error }
   ) => Promise<void> | void;
@@ -1083,9 +1101,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           );
         }
 
-        // 3. Call onUploadStart hook
-        if (routeConfig.onUploadStart) {
-          await routeConfig.onUploadStart({ file, metadata: fileMetadata });
+        // 3. Call onStart hook (supports both new and deprecated name)
+        const onStartHook = routeConfig.onStart || routeConfig.onUploadStart;
+        if (onStartHook) {
+          await onStartHook({ file, metadata: fileMetadata });
         }
 
         // 4. Generate hierarchical file key
@@ -1154,9 +1173,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
       } catch (error) {
         const err = normalizeServerError(error);
 
-        // Call onUploadError hook with enriched metadata
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file,
             metadata: fileMetadata,
             error: err,
@@ -1554,11 +1574,16 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
           routeConfig.downloadExpiresIn ?? 3600
         );
 
-        // Call onUploadComplete hook
-        if (routeConfig.onUploadComplete) {
-          await routeConfig.onUploadComplete({
+        // Call onComplete hook (supports both new and deprecated name)
+        const onCompleteHook = routeConfig.onComplete || routeConfig.onUploadComplete;
+        if (onCompleteHook) {
+          await onCompleteHook({
             file: completion.file,
             metadata: (trustedMetadata || {}) as Record<string, unknown>,
+            storagePath: completion.key,
+            publicUrl: url,
+            presignedUrl,
+            // deprecated aliases
             url,
             key: completion.key,
           });
@@ -1567,7 +1592,9 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
         results.push({
           success: true,
           key: completion.key,
+          storagePath: completion.key,
           url,
+          publicUrl: url,
           presignedUrl,
           file: completion.file,
         });
@@ -1577,9 +1604,10 @@ export class S3Router<TRoutes extends S3RouterDefinition> {
             ? error
             : new Error("Upload completion failed");
 
-        // Call onUploadError hook
-        if (routeConfig.onUploadError) {
-          await routeConfig.onUploadError({
+        // Call onError hook (supports both new and deprecated name)
+        const onErrorHook = routeConfig.onError || routeConfig.onUploadError;
+        if (onErrorHook) {
+          await onErrorHook({
             file: completion.file,
             metadata: (trustedMetadata || {}) as Record<string, unknown>,
             error: err,
@@ -1631,31 +1659,23 @@ export interface UploadCompletion {
 
 export interface CompletionResponse {
   success: boolean;
+  /** Permanent storage path — store this in your database. */
+  storagePath?: string;
+  /** Public URL — store this in your database. */
+  publicUrl?: string;
+  /** Temporary presigned download URL — expires in ~1 hour, do not store. */
+  presignedUrl?: string;
+  /** @deprecated Use `storagePath` instead. */
   key: string;
   /**
    * The object's permanent public URL — your `customDomain` when one is
-   * configured, otherwise the provider URL.
-   *
-   * **Use this for public buckets.** It is unsigned, never expires and keeps
+   * configured, otherwise the provider URL. Unsigned, never expires, keeps
    * CDN caching intact.
+   *
+   * @deprecated Use `publicUrl` (same value) for public buckets, or
+   * `presignedUrl` for private ones.
    */
   url?: string;
-  /**
-   * A temporary signed URL for reading the object, for **private** buckets.
-   *
-   * Expires after the route's `.expiresIn({ download })`, defaulting to one
-   * hour. Independent of the upload window. Always addressed to the provider's
-   * S3 API endpoint, never to `customDomain` — a custom domain is a read-only
-   * CDN front and cannot serve a presigned request. Cloudflare documents this
-   * for R2 explicitly.
-   *
-   * Intended for immediate use. **Persist the `key`, not this URL** — a stored
-   * URL expires while the record still points at it. Mint a fresh one on
-   * demand with `storage.download.presignedUrl(key, ttl)`.
-   *
-   * If your bucket is public, prefer {@link CompletionResponse.url}.
-   */
-  presignedUrl?: string;
   file?: S3FileMetadata;
   error?: string;
 }

--- a/packages/pushduck/src/core/schema.ts
+++ b/packages/pushduck/src/core/schema.ts
@@ -141,6 +141,13 @@ export interface S3FileConstraints {
   maxSize?: string | number;
   /** Minimum file size (string like '1KB' or number in bytes) */
   minSize?: string | number;
+  /**
+   * Accepted file types — mirrors HTML `<input accept>`.
+   * Supports MIME types (`'image/jpeg'`), wildcards (`'image/*'`),
+   * and extensions with dots (`'.pdf'`). Mixes are allowed.
+   * @example s3.file({ accept: ['image/*', '.pdf'] })
+   */
+  accept?: string | string[];
   /** Allowed MIME types (e.g., ['image/jpeg', 'application/pdf']) */
   allowedTypes?: string[];
   /** Allowed file extensions (e.g., ['.jpg', '.pdf']) */
@@ -643,6 +650,23 @@ export class S3FileSchema extends S3Schema<File, File> {
    */
   constructor(protected constraints: S3FileConstraints = {}) {
     super();
+    // Process `accept` shorthand into allowedTypes / allowedExtensions
+    if (constraints.accept) {
+      const acceptArray = Array.isArray(constraints.accept)
+        ? constraints.accept
+        : [constraints.accept];
+      const mimeTypes = acceptArray.filter((t) => !t.startsWith("."));
+      const exts = acceptArray
+        .filter((t) => t.startsWith("."))
+        .map((e) => e.slice(1)); // strip leading dot for internal storage
+      if (mimeTypes.length && !constraints.allowedTypes) {
+        constraints = { ...constraints, allowedTypes: mimeTypes };
+      }
+      if (exts.length && !constraints.allowedExtensions) {
+        constraints = { ...constraints, allowedExtensions: exts };
+      }
+      this.constraints = constraints;
+    }
     this._constraints = { ...constraints };
   }
 
@@ -746,11 +770,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
    * ```
    */
+  /** @deprecated Use `.maxSize()` instead. */
   max(size: string | number): S3FileSchema {
     console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
+      "⚠️ pushduck: .max() is deprecated. Use .maxSize() instead."
     );
-    return new S3FileSchema({ ...this.constraints, maxSize: size });
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  maxFileSize(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead."
+    );
+    return this.maxSize(size);
   }
 
   /**
@@ -761,12 +794,20 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().maxFileSize('10MB');
-   * const schema2 = s3.file().maxFileSize(10485760); // 10MB in bytes
+   * upload.file().maxSize('10MB')
+   * upload.file().maxSize(10485760) // 10MB in bytes
    * ```
    */
-  maxFileSize(size: string | number): S3FileSchema {
+  maxSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, maxSize: size });
+  }
+
+  /** @deprecated Use `.minSize()` instead. */
+  min(size: string | number): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .min() is deprecated. Use .minSize() instead."
+    );
+    return this.minSize(size);
   }
 
   /**
@@ -777,45 +818,54 @@ export class S3FileSchema extends S3Schema<File, File> {
    *
    * @example
    * ```typescript
-   * const schema = s3.file().min('1KB');
-   * const schema2 = s3.file().min(1024); // 1KB in bytes
+   * upload.file().minSize('1KB')
    * ```
    */
-  min(size: string | number): S3FileSchema {
+  minSize(size: string | number): S3FileSchema {
     return new S3FileSchema({ ...this.constraints, minSize: size });
   }
 
   /**
-   * Sets the accepted file types for this upload route.
+   * Sets accepted file types — mirrors HTML `<input accept>`.
+   * Replaces `.types()` and `.extensions()` with a single unified method.
    *
-   * @param mimeTypes - Array of MIME types (e.g., `'image/jpeg'`, `'application/pdf'`, `'video/*'`)
-   * @returns New schema instance with type constraint
-   *
+   * Supports MIME types, wildcards, and extensions (with dots):
    * @example
    * ```typescript
-   * s3.file().accept(['image/jpeg', 'image/png', 'image/webp'])
-   * s3.file().accept(['application/pdf', 'application/msword'])
-   * s3.file().accept(['video/*'])  // wildcard
+   * upload.file().accept('image/*')
+   * upload.file().accept(['image/jpeg', 'image/png'])
+   * upload.file().accept(['.pdf', '.doc'])
+   * upload.file().accept(['image/*', '.pdf']) // mixed
    * ```
    */
-  accept(mimeTypes: MimeType[]): S3FileSchema {
-    return new S3FileSchema({ ...this.constraints, allowedTypes: mimeTypes });
+  accept(types: string | string[]): S3FileSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray
+      .filter((t) => t.startsWith("."))
+      .map((e) => e.slice(1)); // strip leading dot
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3FileSchema(newConstraints);
   }
 
-  /**
-   * @deprecated Use `accept()` instead (e.g., `accept(['image/jpeg', 'image/png'])`).
-   */
-  types(allowedTypes: MimeType[]): S3FileSchema {
-    console.warn("⚠️  The `types()` method is deprecated. Use `accept()` instead.");
+  /** @deprecated Use `.accept()` instead. */
+  types(allowedTypes: string[]): S3FileSchema {
+    console.warn(
+      "⚠️ pushduck: .types() is deprecated. Use .accept() instead."
+    );
     return this.accept(allowedTypes);
   }
 
-  /**
-   * @deprecated Use `accept()` instead with MIME types (e.g., `accept(['.jpg', '.pdf'])`).
-   */
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   extensions(allowedExtensions: string[]): S3FileSchema {
-    console.warn("⚠️  The `extensions()` method is deprecated. Use `accept()` with MIME types instead.");
-    return new S3FileSchema({ ...this.constraints, allowedExtensions });
+    console.warn(
+      "⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead, e.g. .accept([\'.pdf\', \'.doc\'])."
+    );
+    return this.accept(
+      allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`))
+    );
   }
 
   /**
@@ -921,13 +971,36 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onStart()` instead.
+   */
   onUploadStart(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
       metadata: any;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadStart(hook);
+    console.warn('⚠️ pushduck: .onUploadStart() is deprecated. Use .onStart() instead.');
+    return new S3Route(this).onStart(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload starts.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onStart(async ({ file, metadata }) => {
+   *   await logUploadEvent('start', file.name, metadata.userId);
+   * });
+   * ```
+   */
+  onStart(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onStart(hook);
   }
 
   /**
@@ -965,6 +1038,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onComplete()` instead.
+   */
   onUploadComplete(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -973,7 +1049,29 @@ export class S3FileSchema extends S3Schema<File, File> {
       key?: string;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadComplete(hook);
+    console.warn('⚠️ pushduck: .onUploadComplete() is deprecated. Use .onComplete() instead.');
+    return new S3Route(this).onComplete(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload completes successfully.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onComplete(async ({ file, url, key, metadata }) => {
+   *   await db.files.create({ name: file.name, url, uploadedBy: metadata.userId });
+   * });
+   * ```
+   */
+  onComplete(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      url?: string;
+      key?: string;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onComplete(hook);
   }
 
   /**
@@ -1008,6 +1106,9 @@ export class S3FileSchema extends S3Schema<File, File> {
    *   });
    * ```
    */
+  /**
+   * @deprecated Use `.onError()` instead.
+   */
   onUploadError(
     hook: (ctx: {
       file: { name: string; size: number; type: string };
@@ -1015,7 +1116,28 @@ export class S3FileSchema extends S3Schema<File, File> {
       error: Error;
     }) => Promise<void> | void
   ) {
-    return new S3Route(this).onUploadError(hook);
+    console.warn('⚠️ pushduck: .onUploadError() is deprecated. Use .onError() instead.');
+    return new S3Route(this).onError(hook);
+  }
+
+  /**
+   * Adds a hook that executes when file upload fails.
+   *
+   * @example
+   * ```typescript
+   * upload.file().onError(async ({ file, error, metadata }) => {
+   *   await logUploadError({ fileName: file.name, error: error.message });
+   * });
+   * ```
+   */
+  onError(
+    hook: (ctx: {
+      file: { name: string; size: number; type: string };
+      metadata: any;
+      error: Error;
+    }) => Promise<void> | void
+  ) {
+    return new S3Route(this).onError(hook);
   }
 
   /**
@@ -1151,55 +1273,53 @@ export class S3ImageSchema extends S3FileSchema {
     return new S3ImageSchema({ ...this.constraints, allowedTypes: mimeTypes });
   }
 
-  // Override methods to maintain S3ImageSchema type
-  /**
-   * @deprecated Use `maxFileSize()` instead. This method will be removed in a future version.
-   */
+  // Override methods to maintain S3ImageSchema return type
+  /** @deprecated Use `.maxSize()` instead. */
   override max(size: string | number): S3ImageSchema {
-    console.warn(
-      "⚠️  The `max()` method is deprecated. Use `maxFileSize()` instead."
-    );
+    console.warn("⚠️ pushduck: .max() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  /** @deprecated Use `.maxSize()` instead. */
+  override maxFileSize(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .maxFileSize() is deprecated. Use .maxSize() instead.");
+    return this.maxSize(size);
+  }
+
+  override maxSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, maxSize: size });
   }
 
-  /**
-   * Sets the maximum file size constraint.
-   *
-   * @param size - Maximum size as string (e.g., '10MB', '500KB') or number (bytes)
-   * @returns New schema instance with max size constraint
-   *
-   * @example
-   * ```typescript
-   * const schema = s3.image().maxFileSize('10MB');
-   * const schema2 = s3.image().maxFileSize(10485760); // 10MB in bytes
-   * ```
-   */
-  maxFileSize(size: string | number): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, maxSize: size });
-  }
-
+  /** @deprecated Use `.minSize()` instead. */
   override min(size: string | number): S3ImageSchema {
+    console.warn("⚠️ pushduck: .min() is deprecated. Use .minSize() instead.");
+    return this.minSize(size);
+  }
+
+  override minSize(size: string | number): S3ImageSchema {
     return new S3ImageSchema({ ...this.constraints, minSize: size });
   }
 
-  override accept(mimeTypes: MimeType[]): S3ImageSchema {
-    return new S3ImageSchema({ ...this.constraints, allowedTypes: mimeTypes });
+  override accept(types: string | string[]): S3ImageSchema {
+    const typeArray = Array.isArray(types) ? types : [types];
+    const mimeTypes = typeArray.filter((t) => !t.startsWith("."));
+    const exts = typeArray.filter((t) => t.startsWith(".")).map((e) => e.slice(1));
+    const newConstraints = { ...this.constraints };
+    if (mimeTypes.length > 0) newConstraints.allowedTypes = mimeTypes;
+    if (exts.length > 0) newConstraints.allowedExtensions = exts;
+    return new S3ImageSchema(newConstraints);
   }
 
-  /**
-   * @deprecated Use `accept()` instead (e.g., `accept(['image/jpeg', 'image/png'])`).
-   */
-  override types(allowedTypes: MimeType[]): S3ImageSchema {
-    console.warn("⚠️  The `types()` method is deprecated. Use `accept()` instead.");
+  /** @deprecated Use `.accept()` instead. */
+  override types(allowedTypes: string[]): S3ImageSchema {
+    console.warn("⚠️ pushduck: .types() is deprecated. Use .accept() instead.");
     return this.accept(allowedTypes);
   }
 
-  /**
-   * @deprecated Use `accept()` instead with MIME types (e.g., `accept(['image/jpeg', 'image/png'])`).
-   */
+  /** @deprecated Use `.accept(['.ext'])` instead. */
   override extensions(allowedExtensions: string[]): S3ImageSchema {
-    console.warn("⚠️  The `extensions()` method is deprecated. Use `accept()` with MIME types instead.");
-    return new S3ImageSchema({ ...this.constraints, allowedExtensions });
+    console.warn("⚠️ pushduck: .extensions() is deprecated. Use .accept() with dot-prefixed extensions instead.");
+    return this.accept(allowedExtensions.map((e) => (e.startsWith(".") ? e : `.${e}`)));
   }
 
   /**

--- a/packages/pushduck/src/hooks/use-upload-route.ts
+++ b/packages/pushduck/src/hooks/use-upload-route.ts
@@ -235,6 +235,12 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
   const uploadFiles = useCallback(
     async (files: UploadInput[], metadata?: unknown) => {
       await engine.upload(files, metadata);
+      // The beta contract: resolve with the completed files, so callers can
+      // await results directly instead of watching `files` state. Errors
+      // still report through state — this never rejects.
+      return engine
+        .getSnapshot()
+        .files.filter((f) => f.status === "success") as S3UploadedFile[];
     },
     [engine]
   );
@@ -283,3 +289,33 @@ export function useUploadRoute<TRouter extends S3Router<any>>(
  * working; the implementations are shared with every other framework binding.
  */
 export { formatETA, formatUploadSpeed };
+
+/**
+ * Hook for uploading files to a typed route.
+ * Preferred over `useUploadRoute` — hooks should look like hooks.
+ *
+ * @example
+ * ```typescript
+ * const { uploadFiles, files, isUploading } = useUpload<AppRouter>('imageUpload', {
+ *   onComplete: (results) => console.log('done', results),
+ * });
+ *
+ * const results = await uploadFiles(selectedFiles);
+ * ```
+ */
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter>,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload(
+  routeName: string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult;
+
+export function useUpload<TRouter extends S3Router<any>>(
+  routeName: RouterRouteNames<TRouter> | string,
+  config?: UploadRouteConfig
+): S3RouteUploadResult {
+  return useUploadRoute(routeName as string, config);
+}

--- a/packages/pushduck/src/index.ts
+++ b/packages/pushduck/src/index.ts
@@ -9,7 +9,9 @@
 // HOOKS
 // ========================================
 
-// Main upload hook
+// Preferred upload hook — hooks should look like hooks
+export { useUpload } from "./hooks/use-upload-route";
+// Legacy name kept for backward compatibility
 export { useUploadRoute } from "./hooks";
 
 // ========================================
@@ -40,6 +42,11 @@ export type {
   RouterRouteNames,
   S3Router,
   TypedRouteHook,
+  // Provider-neutral aliases
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
 } from "./types";
 
 // ========================================

--- a/packages/pushduck/src/server.ts
+++ b/packages/pushduck/src/server.ts
@@ -101,10 +101,8 @@
  *
  */
 
-// ========================================
-// CONFIGURATION & INITIALIZATION
-// ========================================
-
+// =================================// CONFIGURATION & INITIALIZATION
+// =================================
 /**
  * Provider system for configuring cloud storage services.
  *
@@ -149,10 +147,8 @@ export {
  */
 export { createUploadConfig } from "./core/config/upload-config";
 
-// ========================================
-// SCHEMA BUILDERS
-// ========================================
-
+// =================================// SCHEMA BUILDERS
+// =================================
 /**
  * Type-safe schema system for file validation and transformation.
  * Provides chainable API similar to Zod for defining upload constraints.
@@ -204,10 +200,8 @@ export {
   S3Schema,
 } from "./core/schema";
 
-// ========================================
-// ROUTER SYSTEM
-// ========================================
-
+// =================================// ROUTER SYSTEM
+// =================================
 /**
  * Modern config-aware router system for handling file uploads.
  * Provides type-safe routing with middleware, lifecycle hooks, and automatic presigned URL generation.
@@ -266,10 +260,8 @@ export type { S3Router } from "./types";
 // Frameworks that speak Web-standard Request/Response need no adapter at all —
 // use `router.handlers` directly.
 
-// ========================================
-// STORAGE API
-// ========================================
-
+// =================================// STORAGE API
+// =================================
 /**
  * High-level object-style storage API for direct file operations.
  * Provides a clean interface for file management without dealing with upload routes.
@@ -338,10 +330,8 @@ export { createStorage, StorageInstance } from "./core/storage/storage-api";
  */
 export { createS3Client, resetS3Client } from "./core/storage/client";
 
-// ========================================
-// UTILITIES & HEALTH CHECKS
-// ========================================
-
+// =================================// UTILITIES & HEALTH CHECKS
+// =================================
 /**
  * Comprehensive error handling system with typed error categories.
  * Provides structured error handling for different failure scenarios.
@@ -519,10 +509,8 @@ export {
  */
 export { logger } from "./core/utils/logger";
 
-// ========================================
-// TYPES & INTERFACES
-// ========================================
-
+// =================================// TYPES & INTERFACES
+// =================================
 // Configuration types
 export type {
   AWSProviderConfig,
@@ -614,3 +602,28 @@ export type {
   UploadErrorCode,
   UploadErrorOptions,
 } from "./core/errors";
+// =================================// PROVIDER-NEUTRAL TYPE ALIASES
+// =================================
+// These aliases drop the "S3" prefix so they read naturally when using R2, MinIO, or any provider.
+// The S3-prefixed originals remain fully supported.
+
+export type {
+  UploadRouter,
+  UploadedFile,
+  UploadResult,
+  RouteNames,
+} from "./types";
+
+// Schema aliases
+export type { S3FileConstraints as FileConstraints } from "./core/schema";
+export type { InferS3Input as InferFileInput, InferS3Output as InferFileOutput } from "./core/schema";
+
+// Router/lifecycle aliases
+export type {
+  S3LifecycleContext as LifecycleContext,
+  S3LifecycleHook as LifecycleHook,
+  S3Middleware as Middleware,
+  S3MiddlewareContext as MiddlewareContext,
+  S3RouteContext as RouteContext,
+  S3RouterDefinition as RouterDefinition,
+} from "./core/router/router-v2";

--- a/packages/pushduck/src/types/index.ts
+++ b/packages/pushduck/src/types/index.ts
@@ -77,9 +77,31 @@ export interface S3UploadedFile {
   type: string;
   status: "pending" | "uploading" | "success" | "error";
   progress: number;
-  url?: string;
+  /**
+   * Permanent storage path (e.g. 'uploads/user123/photo.jpg').
+   * Store this in your database — it never expires.
+   */
+  storagePath?: string;
+  /**
+   * Public CDN URL if the bucket/provider has public access configured.
+   * Store this in your database — it never expires.
+   */
+  publicUrl?: string;
+  /**
+   * Temporary presigned download URL — expires in ~1 hour.
+   * Use for immediate display only. Do NOT store in your database.
+   */
+  presignedUrl?: string;
+  /**
+   * @deprecated Use `storagePath` instead. Will be removed in 1.0.0.
+   * The S3 object key — same value as storagePath.
+   */
   key?: string;
-  presignedUrl?: string; // Temporary download URL (expires in 1 hour)
+  /**
+   * @deprecated Use `publicUrl` or `presignedUrl` instead. Will be removed in 1.0.0.
+   * Previously returned the public URL; now ambiguous with presignedUrl.
+   */
+  url?: string;
   /**
    * Human-readable failure message.
    *
@@ -125,6 +147,9 @@ export interface UploadRouteConfig {
   endpoint?: string;
   fetcher?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
   onStart?: (files: S3FileMetadata[]) => void | Promise<void>;
+  /** Called when all uploads complete successfully. Preferred over onSuccess. */
+  onComplete?: (results: S3UploadedFile[]) => void | Promise<void>;
+  /** @deprecated Use onComplete instead. */
   onSuccess?: (results: S3UploadedFile[]) => void | Promise<void>;
   /**
    * Called when an upload fails.
@@ -199,7 +224,20 @@ export interface S3RouteUploadResult {
    * await uploadFiles(files, { albumId: '123', tags: ['vacation'] });
    * ```
    */
-  uploadFiles: (files: File[], metadata?: any) => Promise<void>;
+  /**
+   * Upload files and await the results directly.
+   * Returns the completed file objects — no need to watch `files` state or use `onSuccess`.
+   *
+   * @example
+   * ```typescript
+   * const results = await uploadFiles(selectedFiles);
+   * await db.save({ path: results[0].key });
+   * ```
+   */
+  uploadFiles: (
+    files: UploadInput[],
+    metadata?: unknown
+  ) => Promise<S3UploadedFile[]>;
 
   /**
    * Upload files and resolve with the results, rejecting on batch failure.
@@ -222,8 +260,8 @@ export interface S3RouteUploadResult {
    * ```
    */
   uploadFilesAsync: (
-    files: File[],
-    metadata?: any
+    files: UploadInput[],
+    metadata?: unknown
   ) => Promise<{ files: S3UploadedFile[]; failedFiles: S3UploadedFile[] }>;
 
   /** Reset upload state and clear files */
@@ -371,4 +409,31 @@ export type InferClientRouter<T> =
   }
   : never;
 
-// Legacy types removed - use TypedRouteHook and ClientConfig instead
+// ========================================
+// Provider-Neutral Type Aliases
+// ========================================
+
+/**
+ * Provider-neutral alias for S3Router.
+ * Works regardless of whether you use AWS S3, Cloudflare R2, MinIO, or any other provider.
+ * @alias S3Router
+ */
+export type UploadRouter<TRoutes extends Record<string, any> = Record<string, any>> = S3Router<TRoutes>;
+
+/**
+ * Provider-neutral alias for S3UploadedFile.
+ * @alias S3UploadedFile
+ */
+export type UploadedFile = S3UploadedFile;
+
+/**
+ * Provider-neutral alias for S3RouteUploadResult.
+ * @alias S3RouteUploadResult
+ */
+export type UploadResult = S3RouteUploadResult;
+
+/**
+ * Provider-neutral alias for RouterRouteNames.
+ * @alias RouterRouteNames
+ */
+export type RouteNames<T> = RouterRouteNames<T>;


### PR DESCRIPTION
Lands the beta branch (PRs #171–#178, tracked by #179) on main, conflict-resolved against the stack that landed today. Closes #179. Full type-check and test suite pass locally; CI validates here before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the preferred `useUpload` hook and provider-neutral upload types.
  - Upload calls now return successfully uploaded file details.
  - Added flexible file acceptance rules for MIME types, wildcards, and extensions.
  - Added lifecycle hooks for upload start, progress, completion, and errors.
  - Added standardized file metadata fields, including storage paths and URLs.
  - Upload configuration now exposes the provider-neutral `upload` property.

- **Deprecations**
  - Legacy hook names, metadata fields, configuration properties, and callbacks now issue warnings while remaining supported for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->