### PR TITLE
refactor(python,go): name channels for what they produce

### DIFF
--- a/docs/content/docs/integrations/golang.mdx
+++ b/docs/content/docs/integrations/golang.mdx
@@ -38,7 +38,7 @@ config := pushduck.Config{
 router := pushduck.NewRouter(config, pushduck.Routes{
     "imageUpload": pushduck.Image(
         pushduck.MaxSize("5MB"),
-        pushduck.WithMiddleware(requireUser),
+        pushduck.WithMetadata(requireUser),
         pushduck.OnComplete(saveToDatabase),
     ),
     "documentUpload": pushduck.File(
@@ -48,7 +48,7 @@ router := pushduck.NewRouter(config, pushduck.Routes{
 })
 ```
 
-Middleware authenticates the request and returns the upload's metadata:
+A metadata hook authenticates the request and returns the upload's metadata:
 
 ```go
 func requireUser(r *http.Request, file pushduck.FileMeta) (map[string]any, error) {

--- a/docs/content/docs/integrations/python.mdx
+++ b/docs/content/docs/integrations/python.mdx
@@ -42,8 +42,8 @@ router = Router(config)
 router.add("imageUpload", Route(
     schema=image(max_size="5MB"),
     authorize=[require_session],                       # raise to reject
-    principal=load_user,                               # becomes ctx.user
-    key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",  # a fragment, not the key
+    user=load_user,                                    # becomes ctx.user
+    storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",  # a fragment, not the whole path
     metadata=lambda ctx, f: {"user_id": ctx.user.id},  # the upload's metadata
     on_complete=[record_upload],
 ))
@@ -59,10 +59,10 @@ router.add("documentUpload", Route(
 | Channel | Runs | What it does |
 | --- | --- | --- |
 | `authorize` | once per request | Raise to reject the request. The return value is **ignored**. |
-| `principal` | once per request | Its return value **is** `ctx.user`. |
+| `user` | once per request | Its return value **is** `ctx.user`. |
 | `around` | once per request | `async def f(ctx): ... yield ...` — wraps everything below. |
 | `validate` | per file | Raise to fail **that file**; the rest of the batch continues. |
-| `key` | per file | Returns a key *fragment*. pushduck sanitises it. |
+| `storage_path` | per file | Returns a path *fragment*. pushduck sanitises it. |
 | `metadata` | per file | Its return value **is** the upload's metadata. |
 | `on_complete` | per file | After an upload is confirmed. |
 | `on_error` | on failure | Observational. |
@@ -86,16 +86,16 @@ express by returning nothing.
 
 ### Keys are sanitised, always
 
-The `key` channel returns a fragment. pushduck rejects `..` segments, absolute
+The `storage_path` channel returns a fragment. pushduck rejects `..` segments, absolute
 paths and URL delimiters, then re-sanitises every segment before signing:
 
 ```python
-key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}"
+storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}"
 # "acme/写真 photo.png"  ->  "acme/写真_photo.png"
 # "../../etc/passwd"    ->  CONFIG_INVALID, refused
 ```
 
-This is deliberate and not adjustable. A key hook that is trusted verbatim is
+This is deliberate and not adjustable. A path hook that is trusted verbatim is
 how CVE-2024-39330 (Django) and CVE-2026-34750 (Payload CMS) happened; both
 were fixed by moving the check somewhere an override cannot reach.
 
@@ -107,7 +107,7 @@ and stays correct when a channel is added later:
 ```python
 from dataclasses import replace
 
-tenant = Route(authorize=[require_session], principal=load_user, key=tenant_key)
+tenant = Route(authorize=[require_session], user=load_user, storage_path=tenant_key)
 
 router.add("avatar",   replace(tenant, schema=image(max_size="5MB")))
 router.add("document", replace(tenant, schema=file(max_size="50MB")))
@@ -124,7 +124,7 @@ router = Router(config, defaults=Route(authorize=[require_session]))
 
 ```python
 print(router.describe())
-#   avatar    authorize(1) principal key metadata on_complete(1)
+#   avatar    authorize(1) user storage_path metadata on_complete(1)
 #   public    schema only
 ```
 

--- a/packages/pushduck-go/README.md
+++ b/packages/pushduck-go/README.md
@@ -17,7 +17,7 @@ config := pushduck.Config{
 router := pushduck.NewRouter(config, pushduck.Routes{
     "imageUpload": pushduck.Image(
         pushduck.MaxSize("5MB"),
-        pushduck.WithMiddleware(requireUser),
+        pushduck.WithMetadata(requireUser),
         pushduck.OnComplete(saveToDatabase),
     ),
 })
@@ -82,7 +82,7 @@ the conformance fixtures deliberately match them by shape and cannot:
 
 ## Status
 
-Implemented: introspection, presign, complete, middleware, RFC 9457 errors,
+Implemented: introspection, presign, complete, metadata hooks, RFC 9457 errors,
 completion tokens, per-file validation, SigV4 with temporary credentials,
 S3-compatible endpoints with path-style addressing, and **multipart uploads** —
 init, sign, complete, abort and list, with HMAC session tokens.

--- a/packages/pushduck-go/cmd/conformance-server/main.go
+++ b/packages/pushduck-go/cmd/conformance-server/main.go
@@ -53,11 +53,11 @@ func main() {
 		"fileUpload":  pushduck.File(pushduck.MaxSize("50MB")),
 		"privateUpload": pushduck.File(
 			pushduck.MaxSize("5MB"),
-			pushduck.WithMiddleware(requireAuth),
+			pushduck.WithMetadata(requireAuth),
 		),
 		"strictUpload": pushduck.File(
 			pushduck.MaxSize("5MB"),
-			pushduck.WithMiddleware(strictAuth),
+			pushduck.WithMetadata(strictAuth),
 		),
 	})
 

--- a/packages/pushduck-go/pushduck/config.go
+++ b/packages/pushduck-go/pushduck/config.go
@@ -68,11 +68,11 @@ type FileMeta struct {
 	Type string `json:"type"`
 }
 
-// Middleware authenticates a request and returns metadata for the upload.
+// MetadataHook authenticates a request and returns metadata for the upload.
 //
 // Returning an error rejects the whole request. Return an *Error to control
 // the status; any other error becomes a 500 with its detail withheld.
-type Middleware func(r *http.Request, file FileMeta) (map[string]any, error)
+type MetadataHook func(r *http.Request, file FileMeta) (map[string]any, error)
 
 // CompleteHook runs once an upload finishes.
 //
@@ -85,7 +85,7 @@ type CompleteHook func(r *http.Request, key string, file FileMeta, metadata map[
 type Route struct {
 	MaxSize    int64
 	AllowTypes []string
-	Middleware []Middleware
+	Metadata   []MetadataHook
 	OnComplete CompleteHook
 	// RequireCompletionToken rejects a completion that presents no token.
 	// Off by default so clients older than the token still work.
@@ -114,10 +114,10 @@ func AllowTypes(types ...string) RouteOption {
 	return func(route *Route) { route.AllowTypes = types }
 }
 
-// WithMiddleware appends to the chain; each runs in order and may reject.
-func WithMiddleware(middleware ...Middleware) RouteOption {
+// WithMetadata appends to the metadata chain; each hook runs in order and may reject.
+func WithMetadata(hooks ...MetadataHook) RouteOption {
 	return func(route *Route) {
-		route.Middleware = append(route.Middleware, middleware...)
+		route.Metadata = append(route.Metadata, hooks...)
 	}
 }
 

--- a/packages/pushduck-go/pushduck/mounting_test.go
+++ b/packages/pushduck-go/pushduck/mounting_test.go
@@ -30,7 +30,7 @@ func mountingRouter() *Router {
 		Routes{
 			"imageUpload": Image(
 				MaxSize("5MB"),
-				WithMiddleware(func(r *http.Request, _ FileMeta) (map[string]any, error) {
+				WithMetadata(func(r *http.Request, _ FileMeta) (map[string]any, error) {
 					if r.Header.Get("Authorization") != "Bearer token" {
 						return nil, NewError("UNAUTHORIZED", "Sign in to upload")
 					}
@@ -68,9 +68,9 @@ func assertPresigned(t *testing.T, recorder *httptest.ResponseRecorder) {
 	if !bytes.Contains([]byte(body.Results[0].PresignedURL), []byte("X-Amz-Signature")) {
 		t.Error("presigned URL carries no signature")
 	}
-	// The middleware ran and its output is authoritative.
+	// The hook ran and its output is authoritative.
 	if body.Results[0].Metadata["userId"] != "u1" {
-		t.Errorf("middleware metadata missing: %v", body.Results[0].Metadata)
+		t.Errorf("hook metadata missing: %v", body.Results[0].Metadata)
 	}
 }
 
@@ -113,7 +113,7 @@ func TestWorksBehindMiddleware(t *testing.T) {
 
 	assertPresigned(t, recorder)
 	if !sawRequest {
-		t.Error("the wrapping middleware never ran")
+		t.Error("the wrapping hook never ran")
 	}
 }
 

--- a/packages/pushduck-go/pushduck/multipart.go
+++ b/packages/pushduck-go/pushduck/multipart.go
@@ -5,7 +5,7 @@ package pushduck
 // A multipart upload spans four requests, and the last three have to name the
 // object they act on. If the client sent `{key, uploadId}` directly, anyone
 // could sign parts for — or abort — someone else's upload by guessing or
-// observing that pair. Route middleware authenticates the *caller*; nothing
+// observing that pair. Route metadata hooks authenticate the *caller*; nothing
 // would tie the caller to the object.
 //
 // So `init` returns an opaque token binding the key, upload id and route under
@@ -79,10 +79,10 @@ func (router *Router) verifySession(token string) (multipartSession, error) {
 	return session, nil
 }
 
-// authorizeSession verifies the token *and* re-runs the route's middleware.
+// authorizeSession verifies the token *and* re-runs the route's metadata hooks.
 //
 // Both are required. The token proves which object is being acted on; the
-// middleware proves the caller is still allowed to act. Checking only the token
+// hooks prove the caller is still allowed to act. Checking only the token
 // would let a revoked user finish an upload they started.
 func (router *Router) authorizeSession(
 	r *http.Request, routeName string, route Route, token string,
@@ -96,8 +96,8 @@ func (router *Router) authorizeSession(
 		return multipartSession{}, NewError("FORBIDDEN", "Invalid or expired multipart session")
 	}
 
-	for _, middleware := range route.Middleware {
-		if _, err := middleware(r, FileMeta{Name: session.Key}); err != nil {
+	for _, hook := range route.Metadata {
+		if _, err := hook(r, FileMeta{Name: session.Key}); err != nil {
 			return multipartSession{}, err
 		}
 	}
@@ -181,14 +181,14 @@ func (router *Router) multipartInit(
 			"`file` with name, size and type is required to start a multipart upload")
 	}
 
-	// Middleware and validation run here exactly as they do for a single PUT,
+	// Metadata hooks and validation run here exactly as they do for a single PUT,
 	// so a multipart upload cannot bypass a route's constraints.
 	metadata := map[string]any{}
 	for key, value := range request.Metadata {
 		metadata[key] = value
 	}
-	for _, middleware := range route.Middleware {
-		produced, err := middleware(r, request.File)
+	for _, hook := range route.Metadata {
+		produced, err := hook(r, request.File)
 		if err != nil {
 			return err
 		}

--- a/packages/pushduck-go/pushduck/router.go
+++ b/packages/pushduck-go/pushduck/router.go
@@ -170,7 +170,7 @@ func (router *Router) presign(
 	results := make([]presignResult, 0, len(request.Files))
 
 	for _, file := range request.Files {
-		// Middleware authenticates the *request*, so a rejection fails all of
+		// Metadata hooks authenticate the *request*, so a rejection fails all of
 		// it. This is the distinction the conformance suite pins down: a
 		// request-scoped failure is a status, a file-scoped one is an entry.
 		metadata := map[string]any{}
@@ -178,20 +178,20 @@ func (router *Router) presign(
 			metadata[key] = value
 		}
 
-		for _, middleware := range route.Middleware {
-			produced, err := middleware(r, file)
+		for _, hook := range route.Metadata {
+			produced, err := hook(r, file)
 			if err != nil {
 				return err
 			}
 			// Assigned unconditionally. Keeping the previous value when a
-			// middleware returns nil sounds harmless and is not: that value is
-			// the *client's* metadata, so an authenticate-only middleware —
+			// hook returns nil sounds harmless and is not: that value is
+			// the *client's* metadata, so an authenticate-only hook —
 			// the most natural shape there is — would silently promote the
 			// caller's own identity claims to the ones the application trusts.
 			metadata = produced
 		}
 
-		// A middleware ran and returned nothing, so the upload has no
+		// A hook ran and returned nothing, so the upload has no
 		// metadata. Never the client's.
 		if metadata == nil {
 			metadata = map[string]any{}
@@ -286,8 +286,8 @@ func (router *Router) complete(
 			metadata[key] = value
 		}
 
-		for _, middleware := range route.Middleware {
-			produced, err := middleware(r, entry.File)
+		for _, hook := range route.Metadata {
+			produced, err := hook(r, entry.File)
 			if err != nil {
 				return err
 			}

--- a/packages/pushduck-py/pushduck/router.py
+++ b/packages/pushduck-py/pushduck/router.py
@@ -111,8 +111,8 @@ class Router:
         router.add("avatar", Route(
             schema=image(max_size="5MB"),
             authorize=[require_session],
-            principal=load_user,
-            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            user=load_user,
+            storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
             metadata=lambda ctx, f: {"owner_id": ctx.user.id},
             on_complete=[record_upload],
         ))
@@ -150,9 +150,9 @@ class Router:
                 merged[name] = tuple(shared) + tuple(getattr(route, name))
 
         # Single-slot channels are not merged — two functions cannot both be
-        # the key — so a route's own always wins, and the default fills in only
-        # where the route is silent.
-        for name in ("principal", "key", "metadata", "schema"):
+        # the storage path — so a route's own always wins, and the default
+        # fills in only where the route is silent.
+        for name in ("user", "storage_path", "metadata", "schema"):
             if getattr(route, name) is None and getattr(self.defaults, name) is not None:
                 merged[name] = getattr(self.defaults, name)
 
@@ -277,11 +277,11 @@ class Router:
     # ─── lifecycle ───────────────────────────────────────────────────────────
     #
     #   authorize (list, per request, veto)
-    #   principal (per request, produces ctx.user)
+    #   user      (per request, produces ctx.user)
     #   around    (list, per request, wraps everything below)
     #     schema  (per file, produces a message)
     #     validate(list, per file, veto)
-    #     key     (per file, produces a fragment; the library owns the result)
+    #     storage_path (per file, produces a fragment; the library owns the result)
     #     metadata(per file, produces ctx.metadata)
     #
     # Each channel is named after what it produces, which is what makes
@@ -305,7 +305,7 @@ class Router:
         for check in route.authorize:
             await _invoke(check, request)
 
-        user = await _invoke(route.principal, request) if route.principal is not None else None
+        user = await _invoke(route.user, request) if route.user is not None else None
 
         return Context(
             request=request,
@@ -353,17 +353,17 @@ class Router:
         for check in route.validate:
             await _invoke(check, ctx, file)
 
-        if route.key is not None:
-            # A fragment, not a key. `resolve_key` refuses traversal and
-            # re-sanitises every segment, so a custom key cannot opt out of the
-            # handling that keeps non-Latin filenames from colliding.
-            key = resolve_key(await _invoke(route.key, ctx, file), file.name)
+        if route.storage_path is not None:
+            # A fragment, not a whole path. `resolve_key` refuses traversal and
+            # re-sanitises every segment, so a custom path cannot opt out of
+            # the handling that keeps non-Latin filenames from colliding.
+            key = resolve_key(await _invoke(route.storage_path, ctx, file), file.name)
         else:
             key = generate_key(file.name)
 
         # A per-file view, so one file's key and metadata cannot leak into the
         # next. The request-level context stays the shared, read-mostly part.
-        scoped = _replace(ctx, key=key, metadata={})
+        scoped = _replace(ctx, storage_path=key, metadata={})
 
         metadata: Dict[str, Any] = {}
         if route.metadata is not None:
@@ -502,7 +502,7 @@ class Router:
                 # The metadata channel runs again rather than trusting what the
                 # client echoed back. Its input is the server's context, so the
                 # result cannot contain a claim the application never made.
-                scoped = _replace(ctx, key=key, metadata={})
+                scoped = _replace(ctx, storage_path=key, metadata={})
                 metadata: Dict[str, Any] = {}
                 if route.metadata is not None:
                     produced = await _invoke(route.metadata, scoped, file)
@@ -517,7 +517,7 @@ class Router:
                 for observer in route.on_complete:
                     await _invoke(
                         observer,
-                        _replace(ctx, key=key, metadata=metadata),
+                        _replace(ctx, storage_path=key, metadata=metadata),
                         Completion(key=key, file=file, url=url),
                     )
 
@@ -549,7 +549,7 @@ class Router:
         if session.get("route") != route_name:
             raise UploadError("FORBIDDEN", "Invalid or expired multipart session")
 
-        # Re-runs `authorize` and `principal`, so a revoked user cannot finish
+        # Re-runs `authorize` and `user`, so a revoked user cannot finish
         # an upload they were allowed to start.
         await self._open(route, request, route_name, {})
 

--- a/packages/pushduck-py/pushduck/routes.py
+++ b/packages/pushduck-py/pushduck/routes.py
@@ -59,11 +59,11 @@ from .errors import UploadError
 
 TUser = TypeVar("TUser")
 
-#: The principal of a route that does not authenticate anyone. Spelled as a
-#: type rather than ``None`` so ``Route[Anonymous]`` reads as a decision and
+#: The user type of a route that authenticates nobody. Spelled as a type
+#: rather than ``None`` so ``Route[Anonymous]`` reads as a decision and
 #: ``ctx.user`` still has a name a reader can look up.
 class Anonymous:
-    """No authenticated principal. ``ctx.user`` is ``None``."""
+    """No authenticated user. ``ctx.user`` is ``None``."""
 
     __slots__ = ()
 
@@ -93,15 +93,16 @@ class Context(Generic[TUser]):
     request: Any
     #: The route this upload is for.
     route: str
-    #: Whatever ``principal`` returned, or ``None`` on an anonymous route.
+    #: Whatever the ``user`` channel returned, or ``None`` on an anonymous route.
     user: TUser
     #: What the client sent. Untrusted, always. Never merged into ``metadata``.
     client_metadata: Mapping[str, Any] = field(default_factory=dict)
     #: What the server vouches for. Starts empty; only ``metadata`` fills it.
     metadata: Dict[str, Any] = field(default_factory=dict)
-    #: The resolved object key. Populated before ``metadata`` runs, so metadata
-    #: can reference it; ``None`` earlier in the lifecycle.
-    key: Optional[str] = None
+    #: The resolved storage path (the S3 object key). Populated before
+    #: ``metadata`` runs, so metadata can reference it; ``None`` earlier in the
+    #: lifecycle.
+    storage_path: Optional[str] = None
 
 
 # ─── channel signatures ──────────────────────────────────────────────────────
@@ -112,10 +113,10 @@ class Context(Generic[TUser]):
 MaybeAwaitable = Union[None, Awaitable[None]]
 
 Authorize = Callable[[Any], MaybeAwaitable]
-Principal = Callable[[Any], Any]
+UserResolver = Callable[[Any], Any]
 Around = Callable[["Context[Any]"], AsyncIterator[None]]
 Validate = Callable[["Context[Any]", FileMeta], MaybeAwaitable]
-Key = Callable[["Context[Any]", FileMeta], Union[str, Awaitable[str]]]
+StoragePath = Callable[["Context[Any]", FileMeta], Union[str, Awaitable[str]]]
 Metadata = Callable[
     ["Context[Any]", FileMeta], Union[Mapping[str, Any], Awaitable[Mapping[str, Any]]]
 ]
@@ -127,11 +128,11 @@ OnError = Callable[["Context[Any]", Optional[FileMeta], BaseException], MaybeAwa
 class Route:
     """One named upload endpoint.
 
-    Deliberately *not* generic in the principal, though ``Context`` is. Making
+    Deliberately *not* generic in the user type, though ``Context`` is. Making
     ``Route`` generic reads well and costs more than it returns: mypy cannot
-    infer the parameter from a route that has no ``principal``, so every
+    infer the parameter from a route that has no ``user`` channel, so every
     construction site — including the common one with no authentication at all
-    — reports ``Need type annotation``. A hook that wants a typed principal
+    — reports ``Need type annotation``. A hook that wants a typed user
     annotates its own parameter instead::
 
         def tenant_key(ctx: Context[User], file: FileMeta) -> str:
@@ -147,8 +148,8 @@ class Route:
         Route(
             schema=image(max_size="5MB"),
             authorize=[require_session],
-            principal=load_user,
-            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            user=load_user,
+            storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
             metadata=lambda ctx, f: {"owner_id": ctx.user.id},
             on_complete=[record_upload],
         )
@@ -157,7 +158,7 @@ class Route:
     derives one from another and stays exhaustive when a channel is added
     later::
 
-        tenant = Route(authorize=[require_session], key=tenant_key)
+        tenant = Route(authorize=[require_session], storage_path=tenant_key)
         avatar = replace(tenant, schema=image(max_size="5MB"))
     """
 
@@ -172,7 +173,7 @@ class Route:
     authorize: Sequence[Authorize] = ()
 
     #: Runs once per request. Its return value *is* ``ctx.user``.
-    principal: Optional[Principal] = None
+    user: Optional[UserResolver] = None
 
     #: Async generators that bracket the whole request — one ``yield`` each,
     #: with everything downstream running at the yield. The only channel that
@@ -185,11 +186,11 @@ class Route:
     #: same exception raised from ``authorize`` is a request-level status.
     validate: Sequence[Validate] = ()
 
-    #: Runs per file. Its return value is a key *fragment*, not the key: the
-    #: library rejects traversal, re-sanitises every segment and appends the
-    #: disambiguator. Django moved exactly this validation into ``Storage.save``
+    #: Runs per file. Its return value is a *fragment* of the storage path,
+    #: never the whole path: the library rejects traversal, re-sanitises every
+    #: segment and appends the disambiguator. Django moved exactly this validation into ``Storage.save``
     #: after CVE-2024-39330, so that no override could bypass it.
-    key: Optional[Key] = None
+    storage_path: Optional[StoragePath] = None
 
     #: Runs per file. Its return value *is* ``ctx.metadata``. The client's
     #: metadata is never merged in.
@@ -214,7 +215,7 @@ class Route:
         for name in ("authorize", "validate", "on_complete", "on_error"):
             object.__setattr__(self, name, tuple(_as_async(fn) for fn in getattr(self, name)))
 
-        for name in ("principal", "key", "metadata"):
+        for name in ("user", "storage_path", "metadata"):
             fn = getattr(self, name)
             if fn is not None:
                 object.__setattr__(self, name, _as_async(fn))

--- a/packages/pushduck-py/tests/test_channels.py
+++ b/packages/pushduck-py/tests/test_channels.py
@@ -134,10 +134,10 @@ def test_authorize_return_value_is_ignored():
     assert body_of(response)["results"][0]["metadata"] == {}
 
 
-# ─── principal produces ctx.user ─────────────────────────────────────────────
+# ─── user produces ctx.user ─────────────────────────────────────────────
 
 
-def test_principal_becomes_ctx_user():
+def test_user_channel_becomes_ctx_user():
     class User:
         id = "u_42"
         tenant = "acme"
@@ -147,8 +147,8 @@ def test_principal_becomes_ctx_user():
         "avatar",
         Route(
             schema=image(),
-            principal=lambda request: User(),
-            key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+            user=lambda request: User(),
+            storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
             metadata=lambda ctx, f: {"owner_id": ctx.user.id},
         ),
     )
@@ -217,7 +217,7 @@ def test_key_channel_cannot_escape(fragment):
     """Django moved this validation into `Storage.save()` after CVE-2024-39330
     precisely so that no override could bypass it."""
     router = Router(CONFIG)
-    router.add("avatar", Route(schema=image(), key=lambda ctx, f: fragment))
+    router.add("avatar", Route(schema=image(), storage_path=lambda ctx, f: fragment))
 
     response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
 
@@ -234,7 +234,7 @@ def test_key_channel_output_is_re_sanitised():
     """Without this, the non-Latin filename handling protects only the default
     key and is bypassed by every application that supplies its own."""
     router = Router(CONFIG)
-    router.add("avatar", Route(schema=image(), key=lambda ctx, f: f"tenant/{f.name}"))
+    router.add("avatar", Route(schema=image(), storage_path=lambda ctx, f: f"tenant/{f.name}"))
 
     result = body_of(run(router, presign_request(
         [{"name": "写真 photo.png", "size": 10, "type": "image/png"}]
@@ -303,7 +303,7 @@ def test_around_brackets_the_request():
         Route(
             schema=image(),
             around=[outer, inner],
-            key=lambda ctx, f: order.append("body") or f.name,
+            storage_path=lambda ctx, f: order.append("body") or f.name,
         ),
     )
 
@@ -331,7 +331,7 @@ def test_around_exits_on_failure():
         raise RuntimeError("handler blew up")
 
     router = Router(CONFIG)
-    router.add("avatar", Route(schema=image(), around=[transaction], key=explode))
+    router.add("avatar", Route(schema=image(), around=[transaction], storage_path=explode))
 
     response = run(router, presign_request([{"name": "a.png", "size": 10, "type": "image/png"}]))
 
@@ -385,7 +385,7 @@ def test_on_complete_receives_server_metadata():
 
 def test_replace_derives_a_route():
     """Composition needs no API because a route is a value."""
-    tenant = Route(authorize=[lambda r: None], key=lambda ctx, f: f"t/{f.name}")
+    tenant = Route(authorize=[lambda r: None], storage_path=lambda ctx, f: f"t/{f.name}")
     avatar = replace(tenant, schema=image(max_size="5MB"))
 
     assert avatar.authorize == tenant.authorize
@@ -408,13 +408,13 @@ def test_router_defaults_prepend_rather_than_replace():
 
 def test_describe_lists_channels():
     router = Router(CONFIG)
-    router.add("avatar", Route(schema=image(), authorize=[lambda r: None], key=lambda c, f: "k"))
+    router.add("avatar", Route(schema=image(), authorize=[lambda r: None], storage_path=lambda c, f: "k"))
     router.add("public", Route(schema=file_schema()))
 
     described = router.describe()
 
     assert "authorize(1)" in described
-    assert "key" in described
+    assert "storage_path" in described
     assert "schema only" in described
 
 
@@ -456,7 +456,7 @@ def test_an_unknown_route_name_is_not_reflected_into_a_header():
 def test_sync_and_async_channels_interoperate():
     """Flask users write `def`; FastAPI users write `async def`. Both, in one
     route, resolved once at registration."""
-    async def async_principal(request):
+    async def resolve_user_async(request):
         return {"id": "u_1"}
 
     def sync_metadata(ctx, f):
@@ -464,7 +464,7 @@ def test_sync_and_async_channels_interoperate():
 
     router = Router(CONFIG)
     router.add("avatar", Route(
-        schema=image(), principal=async_principal, metadata=sync_metadata
+        schema=image(), user=resolve_user_async, metadata=sync_metadata
     ))
 
     result = body_of(run(router, presign_request(

--- a/packages/pushduck-py/tests/test_docs_snippets.py
+++ b/packages/pushduck-py/tests/test_docs_snippets.py
@@ -40,8 +40,8 @@ def _body() -> None:
     router.add("imageUpload", Route(
         schema=image(max_size="5MB"),
         authorize=[require_session],
-        principal=load_user,
-        key=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
+        user=load_user,
+        storage_path=lambda ctx, f: f"{ctx.user.tenant}/{f.name}",
         metadata=lambda ctx, f: {"user_id": ctx.user.id},
         on_complete=[record_upload],
     ))
@@ -65,18 +65,18 @@ def _body() -> None:
             json.dumps({"files":[{"name":name,"size":10,"type":"image/png"}]}).encode())))
         return resp.status, json.loads(resp.body)
 
-    st, body = presign(Route(schema=image(), principal=load_user, key=tenant_key), "写真 photo.png")
+    st, body = presign(Route(schema=image(), user=load_user, storage_path=tenant_key), "写真 photo.png")
     assert st == 200, body
     got = body["results"][0]["key"]
     assert got == "acme/写真_photo.png", f"docs claim acme/写真_photo.png, got {got!r}"
 
 
-    st, body = presign(Route(schema=image(), key=lambda ctx,f: "../../etc/passwd"), "a.png")
+    st, body = presign(Route(schema=image(), storage_path=lambda ctx,f: "../../etc/passwd"), "a.png")
     assert st == 500 and body["code"] == "CONFIG_INVALID", body
 
 
     # --- snippet 4: replace()
-    tenant = Route(authorize=[require_session], principal=load_user, key=tenant_key)
+    tenant = Route(authorize=[require_session], user=load_user, storage_path=tenant_key)
     r3 = Router(config)
     r3.add("avatar",   replace(tenant, schema=image(max_size="5MB")))
     r3.add("document", replace(tenant, schema=file(max_size="50MB")))
@@ -88,11 +88,11 @@ def _body() -> None:
 
     # --- snippet 6: describe(), and the exact output the docs print
     r5 = Router(config)
-    r5.add("avatar", Route(schema=image(), authorize=[require_session], principal=load_user,
-                           key=tenant_key, metadata=lambda c,f: {}, on_complete=[record_upload]))
+    r5.add("avatar", Route(schema=image(), authorize=[require_session], user=load_user,
+                           storage_path=tenant_key, metadata=lambda c,f: {}, on_complete=[record_upload]))
     r5.add("public", Route(schema=file()))
     described = r5.describe()
 
-    assert "authorize(1) principal key metadata on_complete(1)" in described, described
+    assert "authorize(1) user storage_path metadata on_complete(1)" in described, described
     assert "schema only" in described, described
 


### PR DESCRIPTION
The remaining renames from the naming audit, confined to the two unpublished packages: Python `principal`→`user`, `key`→`storage_path` (channel + ctx field; wire stays `key`), Go `Middleware`→`MetadataHook`/`WithMetadata`. TS `.middleware()` is deliberately untouched — it is published API and deprecating it needs its own decision.